### PR TITLE
PR 2: internal: transport/test, replace test suites with new transport API

### DIFF
--- a/internal/transport/test/receive_pack.go
+++ b/internal/transport/test/receive_pack.go
@@ -1,5 +1,3 @@
-// Package test implements common test suite for different transport
-// implementations.
 package test
 
 import (
@@ -7,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -18,22 +17,21 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/format/packfile"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp/capability"
-	"github.com/go-git/go-git/v6/plumbing/transport"
 	"github.com/go-git/go-git/v6/storage"
 	"github.com/go-git/go-git/v6/storage/memory"
+	"github.com/go-git/go-git/v6/plumbing/transport"
 )
 
-// ReceivePackSuite is a test suite for receive-pack transport implementations.
+// ReceivePackSuite is a test suite for receive-pack over the new transport API.
 type ReceivePackSuite struct {
 	suite.Suite
-	Endpoint            *transport.Endpoint
-	EmptyEndpoint       *transport.Endpoint
-	NonExistentEndpoint *transport.Endpoint
+	Endpoint            *url.URL
+	EmptyEndpoint       *url.URL
+	NonExistentEndpoint *url.URL
 	Storer              storage.Storer
 	EmptyStorer         storage.Storer
 	NonExistentStorer   storage.Storer
-	EmptyAuth           transport.AuthMethod
-	Client              transport.Transport
+	Transport           transport.Transport
 }
 
 // TearDownTest closes all storers.
@@ -45,14 +43,17 @@ func (s *ReceivePackSuite) TearDownTest() {
 	}
 }
 
+func (s *ReceivePackSuite) packClient() transport.Transport {
+	return s.Transport
+}
+
 // TestAdvertisedReferencesEmpty tests advertised references on an empty repo.
 func (s *ReceivePackSuite) TestAdvertisedReferencesEmpty() {
-	r, err := s.Client.NewSession(s.EmptyStorer, s.EmptyEndpoint, s.EmptyAuth)
+	pc := s.packClient()
+	conn, err := pc.Handshake(context.TODO(), &transport.Request{URL: s.EmptyEndpoint, Command: transport.ReceivePackService})
 	s.Require().NoError(err)
+	defer func() { s.Require().NoError(conn.Close()) }()
 
-	conn, err := r.Handshake(context.TODO(), transport.ReceivePackService)
-	s.Require().NoError(err)
-	defer func() { s.Require().Nil(conn.Close()) }()
 	refs, err := conn.GetRemoteRefs(context.TODO())
 	s.Require().NoError(err)
 	s.Require().Len(refs, 0)
@@ -60,21 +61,17 @@ func (s *ReceivePackSuite) TestAdvertisedReferencesEmpty() {
 
 // TestAdvertisedReferencesNotExists tests advertised references on a non-existent repo.
 func (s *ReceivePackSuite) TestAdvertisedReferencesNotExists() {
-	r, err := s.Client.NewSession(s.NonExistentStorer, s.NonExistentEndpoint, s.EmptyAuth)
-	s.Require().NoError(err)
-
-	_, err = r.Handshake(context.TODO(), transport.ReceivePackService)
+	pc := s.packClient()
+	_, err := pc.Handshake(context.TODO(), &transport.Request{URL: s.NonExistentEndpoint, Command: transport.ReceivePackService})
 	s.Require().Error(err)
 }
 
 // TestCallAdvertisedReferenceTwice tests that calling advertised references twice returns the same result.
 func (s *ReceivePackSuite) TestCallAdvertisedReferenceTwice() {
-	r, err := s.Client.NewSession(s.Storer, s.Endpoint, s.EmptyAuth)
+	pc := s.packClient()
+	conn, err := pc.Handshake(context.TODO(), &transport.Request{URL: s.Endpoint, Command: transport.ReceivePackService})
 	s.Require().NoError(err)
-
-	conn, err := r.Handshake(context.TODO(), transport.ReceivePackService)
-	s.Require().NoError(err)
-	defer func() { s.Require().Nil(conn.Close()) }()
+	defer func() { s.Require().NoError(conn.Close()) }()
 
 	refs1, err := conn.GetRemoteRefs(context.TODO())
 	s.Require().NoError(err)
@@ -87,12 +84,10 @@ func (s *ReceivePackSuite) TestCallAdvertisedReferenceTwice() {
 
 // TestDefaultBranch tests that the default branch is correctly advertised.
 func (s *ReceivePackSuite) TestDefaultBranch() {
-	r, err := s.Client.NewSession(s.Storer, s.Endpoint, s.EmptyAuth)
+	pc := s.packClient()
+	conn, err := pc.Handshake(context.TODO(), &transport.Request{URL: s.Endpoint, Command: transport.ReceivePackService})
 	s.Require().NoError(err)
-
-	conn, err := r.Handshake(context.TODO(), transport.ReceivePackService)
-	s.Require().NoError(err)
-	defer func() { s.Require().Nil(conn.Close()) }()
+	defer func() { s.Require().NoError(conn.Close()) }()
 
 	refs, err := conn.GetRemoteRefs(context.TODO())
 	s.Require().NoError(err)
@@ -111,12 +106,10 @@ func (s *ReceivePackSuite) TestDefaultBranch() {
 
 // TestCapabilities tests that capabilities are correctly reported.
 func (s *ReceivePackSuite) TestCapabilities() {
-	r, err := s.Client.NewSession(s.Storer, s.Endpoint, s.EmptyAuth)
+	pc := s.packClient()
+	conn, err := pc.Handshake(context.TODO(), &transport.Request{URL: s.Endpoint, Command: transport.ReceivePackService})
 	s.Require().NoError(err)
-
-	conn, err := r.Handshake(context.TODO(), transport.ReceivePackService)
-	s.Require().NoError(err)
-	defer func() { s.Require().Nil(conn.Close()) }()
+	defer func() { s.Require().NoError(conn.Close()) }()
 	s.Require().Len(conn.Capabilities().Get("agent"), 1)
 }
 
@@ -143,17 +136,15 @@ func (s *ReceivePackSuite) TestSendPackWithContext() {
 		},
 	}
 
-	r, err := s.Client.NewSession(s.EmptyStorer, s.EmptyEndpoint, s.EmptyAuth)
+	pc := s.packClient()
+	conn, err := pc.Handshake(context.TODO(), &transport.Request{URL: s.EmptyEndpoint, Command: transport.ReceivePackService})
 	s.Require().NoError(err)
-
-	conn, err := r.Handshake(context.TODO(), transport.ReceivePackService)
-	s.Require().NoError(err)
-	defer func() { s.Require().Nil(conn.Close()) }()
+	defer func() { s.Require().NoError(conn.Close()) }()
 
 	ctx, cancel := context.WithCancel(context.TODO())
 	cancel()
 
-	err = conn.Push(ctx, req)
+	err = conn.Push(ctx, s.EmptyStorer, req)
 	s.Require().NotNil(err)
 }
 
@@ -179,7 +170,6 @@ func (s *ReceivePackSuite) TestSendPackOnEmptyWithReportStatus() {
 	req.Commands = []*packp.Command{
 		{Name: "refs/heads/master", Old: plumbing.ZeroHash, New: plumbing.NewHash(fixture.Head)},
 	}
-	// req.Capabilities.Set(capability.ReportStatus)
 	s.receivePack(endpoint, req, fixture, full)
 	s.checkRemoteHead(endpoint, plumbing.NewHash(fixture.Head))
 }
@@ -219,8 +209,6 @@ func (s *ReceivePackSuite) TestSendPackOnNonEmptyWithReportStatus() {
 	req.Commands = []*packp.Command{
 		{Name: "refs/heads/master", Old: plumbing.NewHash(fixture.Head), New: plumbing.NewHash(fixture.Head)},
 	}
-	// req.Capabilities.Set(capability.ReportStatus)
-
 	s.receivePack(endpoint, req, fixture, full)
 	s.checkRemoteHead(endpoint, plumbing.NewHash(fixture.Head))
 }
@@ -235,39 +223,31 @@ func (s *ReceivePackSuite) TestSendPackOnNonEmptyWithReportStatusWithError() {
 		{Name: "refs/heads/master", Old: plumbing.ZeroHash, New: plumbing.NewHash(fixture.Head)},
 	}
 	err := s.receivePackNoCheck(endpoint, req, fixture, full)
-	// XXX: Recent git versions return "failed to update ref", while older
-	//     (>=1.9) return "failed to lock".
-	// More recent versions: command error on <ref>: reference already exists
 	s.Regexp(regexp.MustCompile(".*(failed to update ref|failed to lock|reference already exists).*"), err)
 	s.checkRemoteHead(endpoint, plumbing.NewHash(fixture.Head))
 }
 
-func (s *ReceivePackSuite) receivePackNoCheck(ep *transport.Endpoint,
+func (s *ReceivePackSuite) receivePackNoCheck(ep *url.URL,
 	req *transport.PushRequest, fixture *fixtures.Fixture,
 	callAdvertisedReferences bool,
 ) error {
 	s.T().Helper()
 	ctx := context.TODO()
-	url := ""
+	fixtureURL := ""
 	if fixture != nil {
-		url = fixture.URL
+		fixtureURL = fixture.URL
 	}
 	comment := fmt.Sprintf(
 		"failed with ep=%s fixture=%s callAdvertisedReferences=%v",
-		ep.String(), url, callAdvertisedReferences,
+		ep.String(), fixtureURL, callAdvertisedReferences,
 	)
 
-	// Set write permissions to endpoint directory files. By default
-	// fixtures are generated with read only permissions, this causes
-	// errors deleting or modifying files.
 	rootPath := ep.Path
 	stat, err := os.Stat(ep.Path)
-
 	if rootPath != "" && err == nil && stat.IsDir() {
 		objectPath := filepath.Join(rootPath, "objects/pack")
 		files, err := os.ReadDir(objectPath)
 		s.Require().NoError(err)
-
 		for _, file := range files {
 			path := filepath.Join(objectPath, file.Name())
 			err = os.Chmod(path, 0o644)
@@ -275,10 +255,8 @@ func (s *ReceivePackSuite) receivePackNoCheck(ep *transport.Endpoint,
 		}
 	}
 
-	r, err := s.Client.NewSession(s.EmptyStorer, ep, s.EmptyAuth)
-	s.Require().NoError(err, comment)
-
-	conn, err := r.Handshake(ctx, transport.ReceivePackService)
+	pc := s.packClient()
+	conn, err := pc.Handshake(ctx, &transport.Request{URL: ep, Command: transport.ReceivePackService})
 	s.Require().NoError(err, comment)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
@@ -304,47 +282,38 @@ func (s *ReceivePackSuite) receivePackNoCheck(ep *transport.Endpoint,
 		}
 	}
 
-	return conn.Push(ctx, req)
+	return conn.Push(ctx, s.EmptyStorer, req)
 }
 
-func (s *ReceivePackSuite) receivePack(ep *transport.Endpoint,
+func (s *ReceivePackSuite) receivePack(ep *url.URL,
 	req *transport.PushRequest, fixture *fixtures.Fixture,
 	callAdvertisedReferences bool,
 ) {
 	s.T().Helper()
-	url := ""
+	fixtureURL := ""
 	if fixture != nil {
-		url = fixture.URL
+		fixtureURL = fixture.URL
 	}
-
 	comment := fmt.Sprintf(
 		"failed with ep=%s fixture=%s callAdvertisedReferences=%v",
-		ep.String(), url, callAdvertisedReferences,
+		ep.String(), fixtureURL, callAdvertisedReferences,
 	)
 	err := s.receivePackNoCheck(ep, req, fixture, callAdvertisedReferences)
-	// report, err := s.receivePackNoCheck(ep, req, fixture, callAdvertisedReferences)
 	s.Require().NoError(err, comment)
-	// if req.Capabilities.Supports(capability.ReportStatus) {
-	// 	s.Require().NotNil(report, comment)
-	// 	s.Require().NoError(report.Error(), comment)
-	// } else {
-	// 	s.Require().Nil(report, comment)
-	// }
 }
 
-func (s *ReceivePackSuite) checkRemoteHead(ep *transport.Endpoint, head plumbing.Hash) {
+func (s *ReceivePackSuite) checkRemoteHead(ep *url.URL, head plumbing.Hash) {
 	s.T().Helper()
 	s.checkRemoteReference(ep, plumbing.Master, head)
 }
 
-func (s *ReceivePackSuite) checkRemoteReference(ep *transport.Endpoint,
+func (s *ReceivePackSuite) checkRemoteReference(ep *url.URL,
 	refName plumbing.ReferenceName, head plumbing.Hash,
 ) {
 	s.T().Helper()
 	ctx := context.TODO()
-	r, err := s.Client.NewSession(s.EmptyStorer, ep, s.EmptyAuth)
-	s.Require().NoError(err)
-	conn, err := r.Handshake(ctx, transport.ReceivePackService)
+	pc := s.packClient()
+	conn, err := pc.Handshake(ctx, &transport.Request{URL: ep, Command: transport.ReceivePackService})
 	s.Require().NoError(err)
 	ar, err := conn.GetRemoteRefs(ctx)
 	s.Require().NoError(err, fmt.Sprintf("endpoint: %s", ep.String()))
@@ -363,7 +332,6 @@ func (s *ReceivePackSuite) checkRemoteReference(ep *transport.Endpoint,
 		s.Require().True(ok)
 		s.Require().Equal(head, ref.Hash())
 	}
-
 	s.Require().NoError(conn.Close())
 }
 
@@ -376,10 +344,8 @@ func (s *ReceivePackSuite) TestSendPackAddDeleteReference() {
 func (s *ReceivePackSuite) testSendPackAddReference() {
 	s.T().Helper()
 	ctx := context.TODO()
-	r, err := s.Client.NewSession(s.Storer, s.Endpoint, s.EmptyAuth)
-	s.Require().NoError(err)
-
-	conn, err := r.Handshake(ctx, transport.ReceivePackService)
+	pc := s.packClient()
+	conn, err := pc.Handshake(ctx, &transport.Request{URL: s.Endpoint, Command: transport.ReceivePackService})
 	s.Require().NoError(err)
 
 	refs, err := conn.GetRemoteRefs(ctx)
@@ -388,13 +354,11 @@ func (s *ReceivePackSuite) testSendPackAddReference() {
 	s.Require().NoError(conn.Close())
 
 	fixture := fixtures.Basic().ByTag("packfile").One()
-
 	req := &transport.PushRequest{
 		Commands: []*packp.Command{
 			{Name: "refs/heads/newbranch", Old: plumbing.ZeroHash, New: plumbing.NewHash(fixture.Head)},
 		},
 	}
-
 	s.receivePack(s.Endpoint, req, fixture, false)
 	s.checkRemoteReference(s.Endpoint, "refs/heads/newbranch", plumbing.NewHash(fixture.Head))
 }
@@ -402,10 +366,8 @@ func (s *ReceivePackSuite) testSendPackAddReference() {
 func (s *ReceivePackSuite) testSendPackDeleteReference() {
 	s.T().Helper()
 	ctx := context.TODO()
-	r, err := s.Client.NewSession(s.Storer, s.Endpoint, s.EmptyAuth)
-	s.Require().NoError(err)
-
-	conn, err := r.Handshake(ctx, transport.ReceivePackService)
+	pc := s.packClient()
+	conn, err := pc.Handshake(ctx, &transport.Request{URL: s.Endpoint, Command: transport.ReceivePackService})
 	s.Require().NoError(err)
 
 	caps := conn.Capabilities()
@@ -415,7 +377,6 @@ func (s *ReceivePackSuite) testSendPackDeleteReference() {
 	s.Require().NoError(conn.Close())
 
 	fixture := fixtures.Basic().ByTag("packfile").One()
-
 	req := &transport.PushRequest{
 		Commands: []*packp.Command{
 			{Name: "refs/heads/newbranch", Old: plumbing.NewHash(fixture.Head), New: plumbing.ZeroHash},
@@ -445,6 +406,5 @@ func (s *ReceivePackSuite) emptyPackfile() io.ReadCloser {
 	if err != nil {
 		panic(err)
 	}
-
 	return io.NopCloser(&buf)
 }

--- a/internal/transport/test/upload_pack.go
+++ b/internal/transport/test/upload_pack.go
@@ -1,31 +1,30 @@
-// Package test implements common test suite for different transport
-// implementations.
+// Package test implements common test suites for the new transport API.
 package test
 
 import (
 	"context"
 	"io"
+	"net/url"
 	"time"
 
 	"github.com/stretchr/testify/suite"
 
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp/capability"
-	"github.com/go-git/go-git/v6/plumbing/transport"
 	"github.com/go-git/go-git/v6/storage"
+	"github.com/go-git/go-git/v6/plumbing/transport"
 )
 
-// UploadPackSuite is a test suite for upload-pack transport implementations.
+// UploadPackSuite is a test suite for upload-pack over the new transport API.
 type UploadPackSuite struct {
 	suite.Suite
-	Endpoint            *transport.Endpoint
-	EmptyEndpoint       *transport.Endpoint
-	NonExistentEndpoint *transport.Endpoint
+	Endpoint            *url.URL
+	EmptyEndpoint       *url.URL
+	NonExistentEndpoint *url.URL
 	Storer              storage.Storer
 	EmptyStorer         storage.Storer
 	NonExistentStorer   storage.Storer
-	EmptyAuth           transport.AuthMethod
-	Client              transport.Transport
+	Transport           transport.Transport
 }
 
 // TearDownTest closes all storers.
@@ -37,13 +36,16 @@ func (s *UploadPackSuite) TearDownTest() {
 	}
 }
 
+func (s *UploadPackSuite) packClient() transport.Transport {
+	return s.Transport
+}
+
 // TestAdvertisedReferencesEmpty tests advertised references on an empty repo.
 func (s *UploadPackSuite) TestAdvertisedReferencesEmpty() {
-	r, err := s.Client.NewSession(s.EmptyStorer, s.EmptyEndpoint, s.EmptyAuth)
+	pc := s.packClient()
+	conn, err := pc.Handshake(context.TODO(), &transport.Request{URL: s.EmptyEndpoint, Command: transport.UploadPackService})
 	s.Require().NoError(err)
-	conn, err := r.Handshake(context.TODO(), transport.UploadPackService)
-	s.Require().NoError(err)
-	defer func() { s.Require().Nil(conn.Close()) }()
+	defer func() { s.Require().NoError(conn.Close()) }()
 
 	ar, err := conn.GetRemoteRefs(context.TODO())
 	s.Require().ErrorIs(err, transport.ErrEmptyRemoteRepository)
@@ -52,19 +54,17 @@ func (s *UploadPackSuite) TestAdvertisedReferencesEmpty() {
 
 // TestAdvertisedReferencesNotExists tests advertised references on a non-existent repo.
 func (s *UploadPackSuite) TestAdvertisedReferencesNotExists() {
-	r, err := s.Client.NewSession(s.NonExistentStorer, s.NonExistentEndpoint, s.EmptyAuth)
-	s.Require().NoError(err)
-	_, err = r.Handshake(context.TODO(), transport.UploadPackService)
+	pc := s.packClient()
+	_, err := pc.Handshake(context.TODO(), &transport.Request{URL: s.NonExistentEndpoint, Command: transport.UploadPackService})
 	s.Require().Error(err)
 }
 
 // TestCallAdvertisedReferenceTwice tests that calling advertised references twice returns the same result.
 func (s *UploadPackSuite) TestCallAdvertisedReferenceTwice() {
-	r, err := s.Client.NewSession(s.Storer, s.Endpoint, s.EmptyAuth)
+	pc := s.packClient()
+	conn, err := pc.Handshake(context.TODO(), &transport.Request{URL: s.Endpoint, Command: transport.UploadPackService})
 	s.Require().NoError(err)
-	conn, err := r.Handshake(context.TODO(), transport.UploadPackService)
-	s.Require().NoError(err)
-	defer func() { s.Require().Nil(conn.Close()) }()
+	defer func() { s.Require().NoError(conn.Close()) }()
 
 	ar1, err := conn.GetRemoteRefs(context.TODO())
 	s.Require().NoError(err)
@@ -76,14 +76,12 @@ func (s *UploadPackSuite) TestCallAdvertisedReferenceTwice() {
 
 // TestDefaultBranch tests that the default branch is correctly advertised.
 func (s *UploadPackSuite) TestDefaultBranch() {
-	ctx := context.TODO()
-	r, err := s.Client.NewSession(s.Storer, s.Endpoint, s.EmptyAuth)
+	pc := s.packClient()
+	conn, err := pc.Handshake(context.TODO(), &transport.Request{URL: s.Endpoint, Command: transport.UploadPackService})
 	s.Require().NoError(err)
-	conn, err := r.Handshake(ctx, transport.UploadPackService)
-	s.Require().NoError(err)
-	defer func() { s.Require().Nil(conn.Close()) }()
+	defer func() { s.Require().NoError(conn.Close()) }()
 
-	info, err := conn.GetRemoteRefs(ctx)
+	info, err := conn.GetRemoteRefs(context.TODO())
 	s.Require().NoError(err)
 	s.Require().NotNil(info)
 	symrefs := conn.Capabilities().Get(capability.SymRef)
@@ -93,11 +91,10 @@ func (s *UploadPackSuite) TestDefaultBranch() {
 
 // TestAdvertisedReferencesFilterUnsupported tests filtering unsupported capabilities.
 func (s *UploadPackSuite) TestAdvertisedReferencesFilterUnsupported() {
-	r, err := s.Client.NewSession(s.Storer, s.Endpoint, s.EmptyAuth)
+	pc := s.packClient()
+	conn, err := pc.Handshake(context.TODO(), &transport.Request{URL: s.Endpoint, Command: transport.UploadPackService})
 	s.Require().NoError(err)
-	conn, err := r.Handshake(context.TODO(), transport.UploadPackService)
-	s.Require().NoError(err)
-	defer func() { s.Require().Nil(conn.Close()) }()
+	defer func() { s.Require().NoError(conn.Close()) }()
 
 	info, err := conn.GetRemoteRefs(context.TODO())
 	s.Require().NoError(err)
@@ -107,11 +104,10 @@ func (s *UploadPackSuite) TestAdvertisedReferencesFilterUnsupported() {
 
 // TestCapabilities tests that capabilities are correctly reported.
 func (s *UploadPackSuite) TestCapabilities() {
-	r, err := s.Client.NewSession(s.Storer, s.Endpoint, s.EmptyAuth)
+	pc := s.packClient()
+	conn, err := pc.Handshake(context.TODO(), &transport.Request{URL: s.Endpoint, Command: transport.UploadPackService})
 	s.Require().NoError(err)
-	conn, err := r.Handshake(context.TODO(), transport.UploadPackService)
-	s.Require().NoError(err)
-	defer func() { s.Require().Nil(conn.Close()) }()
+	defer func() { s.Require().NoError(conn.Close()) }()
 
 	info, err := conn.GetRemoteRefs(context.TODO())
 	s.Require().NoError(err)
@@ -121,21 +117,19 @@ func (s *UploadPackSuite) TestCapabilities() {
 
 // TestUploadPack tests a basic upload-pack fetch.
 func (s *UploadPackSuite) TestUploadPack() {
-	r, err := s.Client.NewSession(s.Storer, s.Endpoint, s.EmptyAuth)
+	pc := s.packClient()
+	conn, err := pc.Handshake(context.TODO(), &transport.Request{URL: s.Endpoint, Command: transport.UploadPackService})
 	s.Require().NoError(err)
-	conn, err := r.Handshake(context.TODO(), transport.UploadPackService)
-	s.Require().NoError(err)
-	defer func() { s.Require().Nil(conn.Close()) }()
+	defer func() { s.Require().NoError(conn.Close()) }()
 
 	beforeCount := s.countObjects(s.Storer)
 	req := &transport.FetchRequest{}
 	req.Wants = append(req.Wants, plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
 
-	err = conn.Fetch(context.Background(), req)
+	err = conn.Fetch(context.Background(), s.Storer, req)
 	s.Require().NoError(err)
 
 	afterCount := s.countObjects(s.Storer)
-
 	s.Require().Equal(28, afterCount-beforeCount)
 }
 
@@ -144,11 +138,10 @@ func (s *UploadPackSuite) TestUploadPackWithContext() {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
 	defer cancel()
 
-	r, err := s.Client.NewSession(s.Storer, s.Endpoint, s.EmptyAuth)
+	pc := s.packClient()
+	conn, err := pc.Handshake(context.TODO(), &transport.Request{URL: s.Endpoint, Command: transport.UploadPackService})
 	s.Require().NoError(err)
-	conn, err := r.Handshake(context.TODO(), transport.UploadPackService)
-	s.Require().NoError(err)
-	defer func() { s.Require().Nil(conn.Close()) }()
+	defer func() { s.Require().NoError(conn.Close()) }()
 
 	info, err := conn.GetRemoteRefs(context.TODO())
 	s.Require().NoError(err)
@@ -157,7 +150,7 @@ func (s *UploadPackSuite) TestUploadPackWithContext() {
 	req := &transport.FetchRequest{}
 	req.Wants = append(req.Wants, plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
 
-	err = conn.Fetch(ctx, req)
+	err = conn.Fetch(ctx, s.Storer, req)
 	s.Require().NotNil(err)
 }
 
@@ -165,11 +158,10 @@ func (s *UploadPackSuite) TestUploadPackWithContext() {
 func (s *UploadPackSuite) TestUploadPackWithContextOnRead() {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	r, err := s.Client.NewSession(s.Storer, s.Endpoint, s.EmptyAuth)
+	pc := s.packClient()
+	conn, err := pc.Handshake(context.TODO(), &transport.Request{URL: s.Endpoint, Command: transport.UploadPackService})
 	s.Require().NoError(err)
-	conn, err := r.Handshake(context.TODO(), transport.UploadPackService)
-	s.Require().NoError(err)
-	defer func() { s.Require().Nil(conn.Close()) }()
+	defer func() { s.Require().NoError(conn.Close()) }()
 
 	info, err := conn.GetRemoteRefs(context.TODO())
 	s.Require().NoError(err)
@@ -179,17 +171,16 @@ func (s *UploadPackSuite) TestUploadPackWithContextOnRead() {
 	req.Wants = append(req.Wants, plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
 
 	cancel()
-	err = conn.Fetch(ctx, req)
+	err = conn.Fetch(ctx, s.Storer, req)
 	s.Require().NotNil(err)
 }
 
 // TestUploadPackFull tests a full upload-pack fetch with advertised references.
 func (s *UploadPackSuite) TestUploadPackFull() {
-	r, err := s.Client.NewSession(s.Storer, s.Endpoint, s.EmptyAuth)
+	pc := s.packClient()
+	conn, err := pc.Handshake(context.TODO(), &transport.Request{URL: s.Endpoint, Command: transport.UploadPackService})
 	s.Require().NoError(err)
-	conn, err := r.Handshake(context.TODO(), transport.UploadPackService)
-	s.Require().NoError(err)
-	defer func() { s.Require().Nil(conn.Close()) }()
+	defer func() { s.Require().NoError(conn.Close()) }()
 
 	info, err := conn.GetRemoteRefs(context.TODO())
 	s.Require().NoError(err)
@@ -199,7 +190,7 @@ func (s *UploadPackSuite) TestUploadPackFull() {
 	req := &transport.FetchRequest{}
 	req.Wants = append(req.Wants, plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
 
-	err = conn.Fetch(context.Background(), req)
+	err = conn.Fetch(context.Background(), s.Storer, req)
 	s.Require().NoError(err)
 
 	afterCount := s.countObjects(s.Storer)
@@ -208,33 +199,30 @@ func (s *UploadPackSuite) TestUploadPackFull() {
 
 // TestUploadPackInvalidReq tests upload-pack with an invalid request.
 func (s *UploadPackSuite) TestUploadPackInvalidReq() {
-	r, err := s.Client.NewSession(s.Storer, s.Endpoint, s.EmptyAuth)
+	pc := s.packClient()
+	conn, err := pc.Handshake(context.TODO(), &transport.Request{URL: s.Endpoint, Command: transport.UploadPackService})
 	s.Require().NoError(err)
-	conn, err := r.Handshake(context.TODO(), transport.UploadPackService)
-	s.Require().NoError(err)
-	defer func() { s.Require().Nil(conn.Close()) }()
+	defer func() { s.Require().NoError(conn.Close()) }()
 
 	req := &transport.FetchRequest{}
 	req.Wants = append(req.Wants, plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
-	// Invalid capabilities are now handled by the transport layer
 
-	err = conn.Fetch(context.Background(), req)
-	s.Require().NoError(err) // Should succeed as invalid capabilities are handled internally
+	err = conn.Fetch(context.Background(), s.Storer, req)
+	s.Require().NoError(err)
 }
 
 // TestUploadPackNoChanges tests upload-pack when there are no changes.
 func (s *UploadPackSuite) TestUploadPackNoChanges() {
-	r, err := s.Client.NewSession(s.Storer, s.Endpoint, s.EmptyAuth)
+	pc := s.packClient()
+	conn, err := pc.Handshake(context.TODO(), &transport.Request{URL: s.Endpoint, Command: transport.UploadPackService})
 	s.Require().NoError(err)
-	conn, err := r.Handshake(context.TODO(), transport.UploadPackService)
-	s.Require().NoError(err)
-	defer func() { s.Require().Nil(conn.Close()) }()
+	defer func() { s.Require().NoError(conn.Close()) }()
 
 	req := &transport.FetchRequest{}
 	req.Wants = append(req.Wants, plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
 	req.Haves = append(req.Haves, plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
 
-	err = conn.Fetch(context.Background(), req)
+	err = conn.Fetch(context.Background(), s.Storer, req)
 	s.Require().ErrorIs(err, transport.ErrNoChange)
 }
 
@@ -255,14 +243,13 @@ func (s *UploadPackSuite) TestUploadPackPartial() {
 }
 
 func (s *UploadPackSuite) testUploadPackFetch(req *transport.FetchRequest, expectedObjects int) {
-	r, err := s.Client.NewSession(s.Storer, s.Endpoint, s.EmptyAuth)
+	pc := s.packClient()
+	conn, err := pc.Handshake(context.TODO(), &transport.Request{URL: s.Endpoint, Command: transport.UploadPackService})
 	s.Require().NoError(err)
-	conn, err := r.Handshake(context.TODO(), transport.UploadPackService)
-	s.Require().NoError(err)
-	defer func() { s.Require().Nil(conn.Close()) }()
+	defer func() { s.Require().NoError(conn.Close()) }()
 
 	beforeCount := s.countObjects(s.Storer)
-	err = conn.Fetch(context.Background(), req)
+	err = conn.Fetch(context.Background(), s.Storer, req)
 	s.Require().NoError(err)
 
 	afterCount := s.countObjects(s.Storer)
@@ -271,20 +258,16 @@ func (s *UploadPackSuite) testUploadPackFetch(req *transport.FetchRequest, expec
 
 // TestFetchError tests that fetching a non-existent object returns an error.
 func (s *UploadPackSuite) TestFetchError() {
-	r, err := s.Client.NewSession(s.Storer, s.Endpoint, s.EmptyAuth)
+	pc := s.packClient()
+	conn, err := pc.Handshake(context.TODO(), &transport.Request{URL: s.Endpoint, Command: transport.UploadPackService})
 	s.Require().NoError(err)
-	conn, err := r.Handshake(context.TODO(), transport.UploadPackService)
-	s.Require().NoError(err)
-	defer func() { s.Require().Nil(conn.Close()) }()
+	defer func() { s.Require().NoError(conn.Close()) }()
 
 	req := &transport.FetchRequest{}
 	req.Wants = append(req.Wants, plumbing.NewHash("1111111111111111111111111111111111111111"))
 
-	err = conn.Fetch(context.Background(), req)
+	err = conn.Fetch(context.Background(), s.Storer, req)
 	s.Require().NotNil(err)
-
-	// XXX: We do not test Close error, since implementations might return
-	//     different errors if a previous error was found.
 }
 
 func (s *UploadPackSuite) countObjects(st storage.Storer) int {


### PR DESCRIPTION
## Summary

Replace the old `internal/transport/test` upload pack and receive pack test suites with the new versions from `x/transport/test/`. These new suites test against the new `plumbing/transport` API introduced in PR 1.

The shared helper file `internal/transport/test/common.go` (containing `PrepareRepository`, `ListenTCP`, etc.) is kept as-is — it is used by both old and new suites.

## What changed

**Modified files:**
- `internal/transport/test/upload_pack.go` — replaced with new test suite
- `internal/transport/test/receive_pack.go` — replaced with new test suite

**2 files changed**, 111 insertions, 168 deletions.

## Dependencies

- Depends on [#5](https://github.com/aymanbagabas/go-git/pull/5) (PR 1: core transport replacement)

## PR Stack

This is **PR 2 of 11** in the transport migration stack.

| # | PR | Description | Status |
|---|-----|-------------|--------|
| 1 | [#5](https://github.com/aymanbagabas/go-git/pull/5) | Replace `plumbing/transport` core | |
| 2 | [#6](https://github.com/aymanbagabas/go-git/pull/6) | Replace `internal/transport/test` suites | |
| 3 | [#7](https://github.com/aymanbagabas/go-git/pull/7) | Replace `plumbing/transport/ssh` | |
| 4 | [#8](https://github.com/aymanbagabas/go-git/pull/8) | Replace `plumbing/transport/http` | |
| 5 | [#9](https://github.com/aymanbagabas/go-git/pull/9) | Replace `plumbing/transport/git` | |
| 6 | [#10](https://github.com/aymanbagabas/go-git/pull/10) | Replace `plumbing/transport/file` | |
| 7 | [#11](https://github.com/aymanbagabas/go-git/pull/11) | Add `plumbing/client` | |
| 8 | [#12](https://github.com/aymanbagabas/go-git/pull/12) | Rewire callers | |
| 9 | [#13](https://github.com/aymanbagabas/go-git/pull/13) | Rewire server/backends | |
| 10 | [#14](https://github.com/aymanbagabas/go-git/pull/14) | Update examples | |
| 11 | [#15](https://github.com/aymanbagabas/go-git/pull/15) | Fix build errors | |