### PR TITLE
PR 8: git: rewire callers to new transport API

### DIFF
--- a/options.go
+++ b/options.go
@@ -14,7 +14,7 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp/sideband"
-	"github.com/go-git/go-git/v6/plumbing/transport"
+	"github.com/go-git/go-git/v6/plumbing/client"
 )
 
 // SubmoduleRecursivity defines how depth will affect any submodule recursive
@@ -38,8 +38,10 @@ var ErrMissingURL = errors.New("URL field is required")
 type CloneOptions struct {
 	// The (possibly remote) repository URL to clone from.
 	URL string
-	// Auth credentials, if required, to use with the remote repository.
-	Auth transport.AuthMethod
+	// ClientOptions configures the transport client used for this operation.
+	// Use client.WithSSHAuth, client.WithHTTPAuth, client.WithInsecureSkipTLS,
+	// client.WithCABundle, client.WithProxyURL, etc.
+	ClientOptions []client.Option
 	// Name of the remote to be added, by default `origin`.
 	RemoteName string
 	// Remote branch to clone.
@@ -72,12 +74,6 @@ type CloneOptions struct {
 	// Tags describe how the tags will be fetched from the remote repository,
 	// by default is AllTags.
 	Tags plumbing.TagMode
-	// InsecureSkipTLS skips ssl verify if protocol is https
-	InsecureSkipTLS bool
-	// CABundle specify additional ca bundle with system cert pool
-	CABundle []byte
-	// ProxyOptions provides info required for connecting to a proxy.
-	ProxyOptions transport.ProxyOptions
 	// When the repository to clone is on the local machine, instead of
 	// using hard links, automatically setup .git/objects/info/alternates
 	// to share the objects with the source repository.
@@ -167,8 +163,8 @@ type PullOptions struct {
 	SingleBranch bool
 	// Limit fetching to the specified number of commits.
 	Depth int
-	// Auth credentials, if required, to use with the remote repository.
-	Auth transport.AuthMethod
+	// ClientOptions configures the transport client used for this operation.
+	ClientOptions []client.Option
 	// RecurseSubmodules controls if new commits of all populated submodules
 	// should be fetched too.
 	RecurseSubmodules SubmoduleRecursivity
@@ -179,12 +175,6 @@ type PullOptions struct {
 	// Force allows the pull to update a local branch even when the remote
 	// branch does not descend from it.
 	Force bool
-	// InsecureSkipTLS skips ssl verify if protocol is https
-	InsecureSkipTLS bool
-	// CABundle specify additional ca bundle with system cert pool
-	CABundle []byte
-	// ProxyOptions provides info required for connecting to a proxy.
-	ProxyOptions transport.ProxyOptions
 }
 
 // Validate validates the fields and sets the default values.
@@ -224,8 +214,8 @@ type FetchOptions struct {
 	// Depth limit fetching to the specified number of commits from the tip of
 	// each remote branch history.
 	Depth int
-	// Auth credentials, if required, to use with the remote repository.
-	Auth transport.AuthMethod
+	// ClientOptions configures the transport client used for this operation.
+	ClientOptions []client.Option
 	// Progress is where the human readable information sent by the server is
 	// stored, if nil nothing is stored and the capability (if supported)
 	// no-progress, is sent to the server to avoid send this information.
@@ -236,12 +226,6 @@ type FetchOptions struct {
 	// Force allows the fetch to update a local branch even when the remote
 	// branch does not descend from it.
 	Force bool
-	// InsecureSkipTLS skips ssl verify if protocol is https
-	InsecureSkipTLS bool
-	// CABundle specify additional ca bundle with system cert pool
-	CABundle []byte
-	// ProxyOptions provides info required for connecting to a proxy.
-	ProxyOptions transport.ProxyOptions
 	// Prune specify that local refs that match given RefSpecs and that do
 	// not exist remotely will be removed.
 	Prune bool
@@ -284,8 +268,8 @@ type PushOptions struct {
 	//
 	// A refspec with empty src can be used to delete a reference.
 	RefSpecs []config.RefSpec
-	// Auth credentials, if required, to use with the remote repository.
-	Auth transport.AuthMethod
+	// ClientOptions configures the transport client used for this operation.
+	ClientOptions []client.Option
 	// Progress is where the human readable information sent by the server is
 	// stored, if nil nothing is stored.
 	Progress sideband.Progress
@@ -295,10 +279,6 @@ type PushOptions struct {
 	// Force allows the push to update a remote branch even when the local
 	// branch does not descend from it.
 	Force bool
-	// InsecureSkipTLS skips ssl verify if protocol is https
-	InsecureSkipTLS bool
-	// CABundle specify additional ca bundle with system cert pool
-	CABundle []byte
 	// RequireRemoteRefs only allows a remote ref to be updated if its current
 	// value is the one specified here.
 	RequireRemoteRefs []config.RefSpec
@@ -311,8 +291,6 @@ type PushOptions struct {
 	Options []string
 	// Atomic sets option to be an atomic push
 	Atomic bool
-	// ProxyOptions provides info required for connecting to a proxy.
-	ProxyOptions transport.ProxyOptions
 	// Quiet indicates whether the server should suppress human-readable
 	// output.
 	Quiet bool
@@ -363,8 +341,8 @@ type SubmoduleUpdateOptions struct {
 	// the current repository but also in any nested submodules inside those
 	// submodules (and so on). Until the SubmoduleRecursivity is reached.
 	RecurseSubmodules SubmoduleRecursivity
-	// Auth credentials, if required, to use with the remote repository.
-	Auth transport.AuthMethod
+	// ClientOptions configures the transport client used for this operation.
+	ClientOptions []client.Option
 	// Depth limit fetching to the specified number of commits from the tip of
 	// each remote branch history.
 	Depth int
@@ -739,17 +717,11 @@ func (o *CreateTagOptions) loadConfigTagger(r *Repository) error {
 
 // ListOptions describes how a remote list should be performed.
 type ListOptions struct {
-	// Auth credentials, if required, to use with the remote repository.
-	Auth transport.AuthMethod
-	// InsecureSkipTLS skips ssl verify if protocol is https
-	InsecureSkipTLS bool
-	// CABundle specify additional ca bundle with system cert pool
-	CABundle []byte
+	// ClientOptions configures the transport client used for this operation.
+	ClientOptions []client.Option
 	// PeelingOption defines how peeled objects are handled during a
 	// remote list.
 	PeelingOption PeelingOption
-	// ProxyOptions provides info required for connecting to a proxy.
-	ProxyOptions transport.ProxyOptions
 	// Timeout specifies the timeout in seconds for list operations
 	Timeout int
 }

--- a/remote.go
+++ b/remote.go
@@ -19,6 +19,7 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/revlist"
 	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/plumbing/transport"
+	"github.com/go-git/go-git/v6/plumbing/client"
 	"github.com/go-git/go-git/v6/storage"
 	"github.com/go-git/go-git/v6/storage/memory"
 	"github.com/go-git/go-git/v6/utils/ioutil"
@@ -106,22 +107,18 @@ func (r *Remote) PushContext(ctx context.Context, o *PushOptions) (err error) {
 		o.RemoteURL = r.c.URLs[len(r.c.URLs)-1]
 	}
 
-	c, ep, err := newClient(o.RemoteURL, o.InsecureSkipTLS, o.CABundle, o.ProxyOptions)
+	cl, req, err := newClient(o.RemoteURL, o.ClientOptions)
 	if err != nil {
 		return err
 	}
 
-	s, err := c.NewSession(r.s, ep, o.Auth)
+	req.Command = transport.ReceivePackService
+	sess, err := cl.Handshake(ctx, req)
 	if err != nil {
 		return err
 	}
 
-	conn, err := s.Handshake(ctx, transport.ReceivePackService)
-	if err != nil {
-		return err
-	}
-
-	rRefs, err := conn.GetRemoteRefs(ctx)
+	rRefs, err := sess.GetRemoteRefs(ctx)
 	if err != nil {
 		return err
 	}
@@ -131,10 +128,10 @@ func (r *Remote) PushContext(ctx context.Context, o *PushOptions) (err error) {
 		return err
 	}
 
-	return r.sendPack(ctx, conn, remoteRefs, o)
+	return r.sendPack(ctx, sess, remoteRefs, o)
 }
 
-func (r *Remote) sendPack(ctx context.Context, conn transport.Connection, remoteRefs storer.ReferenceStorer, o *PushOptions) error {
+func (r *Remote) sendPack(ctx context.Context, sess transport.Session, remoteRefs storer.ReferenceStorer, o *PushOptions) error {
 	isDelete := false
 	allDelete := true
 	for _, rs := range o.RefSpecs {
@@ -149,7 +146,7 @@ func (r *Remote) sendPack(ctx context.Context, conn transport.Connection, remote
 	}
 
 	// TODO: support delete-refs
-	caps := conn.Capabilities() // server capabilities
+	caps := sess.Capabilities() // server capabilities
 	if isDelete && !caps.Supports(capability.DeleteRefs) {
 		return ErrDeleteRefNotSupported
 	}
@@ -374,26 +371,22 @@ func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (sto storer.Referen
 		o.RemoteURL = r.c.URLs[0]
 	}
 
-	c, ep, err := newClient(o.RemoteURL, o.InsecureSkipTLS, o.CABundle, o.ProxyOptions)
+	cl, req, err := newClient(o.RemoteURL, o.ClientOptions)
 	if err != nil {
 		return nil, err
 	}
 
-	sess, err := c.NewSession(r.s, ep, o.Auth)
+	req.Command = transport.UploadPackService
+	sess, err := cl.Handshake(ctx, req)
 	if err != nil {
 		return nil, err
 	}
 
-	conn, err := sess.Handshake(ctx, transport.UploadPackService)
-	if err != nil {
+	if err := r.isSupportedRefSpec(o.RefSpecs, sess.Capabilities(); err != nil {
 		return nil, err
 	}
 
-	if err := r.isSupportedRefSpec(o.RefSpecs, conn.Capabilities()); err != nil {
-		return nil, err
-	}
-
-	rRefs, err := conn.GetRemoteRefs(ctx)
+	rRefs, err := sess.GetRemoteRefs(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -463,14 +456,14 @@ func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (sto storer.Referen
 			Filter:      o.Filter,
 		}
 
-		if err := conn.Fetch(ctx, req); err != nil && !errors.Is(err, transport.ErrNoChange) {
+		if err := sess.Fetch(ctx, r.s, req); err != nil && !errors.Is(err, transport.ErrNoChange) {
 			// Note: We receive ErrNoChange when remote is the same as local. At
 			// this point, we have everything we're asking for.
 			return nil, err
 		}
 	}
 
-	if err := conn.Close(); err != nil {
+	if err := sess.Close(); err != nil {
 		return nil, fmt.Errorf("error closing connection: %w", err)
 	}
 
@@ -546,21 +539,14 @@ func depthChanged(before []plumbing.Hash, s storage.Storer) (bool, error) {
 	return false, nil
 }
 
-func newClient(url string, insecure bool, cabundle []byte, proxyOpts transport.ProxyOptions) (transport.Transport, *transport.Endpoint, error) {
-	ep, err := transport.NewEndpoint(url)
-	if err != nil {
-		return nil, nil, err
-	}
-	ep.InsecureSkipTLS = insecure
-	ep.CaBundle = cabundle
-	ep.Proxy = proxyOpts
-
-	c, err := transport.Get(ep.Scheme)
+func newClient(rawURL string, opts []client.Option) (*client.Client, *transport.Request, error) {
+	u, err := transport.ParseURL(rawURL)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return c, ep, err
+	cl := client.New(opts...)
+	return cl, &transport.Request{URL: u}, nil
 }
 
 func (r *Remote) pruneRemotes(specs []config.RefSpec, localRefs []*plumbing.Reference, remoteRefs storer.ReferenceStorer) (bool, error) {
@@ -1300,24 +1286,20 @@ func (r *Remote) list(ctx context.Context, o *ListOptions) (rfs []*plumbing.Refe
 		return nil, ErrEmptyUrls
 	}
 
-	c, ep, err := newClient(r.c.URLs[0], o.InsecureSkipTLS, o.CABundle, o.ProxyOptions)
+	cl, req, err := newClient(r.c.URLs[0], o.ClientOptions)
 	if err != nil {
 		return nil, err
 	}
 
-	s, err := c.NewSession(r.s, ep, o.Auth)
+	req.Command = transport.UploadPackService
+	sess, err := cl.Handshake(ctx, req)
 	if err != nil {
 		return nil, err
 	}
 
-	conn, err := s.Handshake(ctx, transport.UploadPackService)
-	if err != nil {
-		return nil, err
-	}
+	defer ioutil.CheckClose(sess, &err)
 
-	defer ioutil.CheckClose(conn, &err)
-
-	allRefs, err := conn.GetRemoteRefs(ctx)
+	allRefs, err := sess.GetRemoteRefs(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -1377,14 +1359,14 @@ func referencesToHashes(refs storer.ReferenceStorer) ([]plumbing.Hash, error) {
 
 func pushHashes(
 	ctx context.Context,
-	conn transport.Connection,
+	sess transport.Session,
 	s storage.Storer,
 	cmds []*packp.Command,
 	hs []plumbing.Hash,
 	allDelete bool,
 	o *PushOptions,
 ) error {
-	useRefDeltas := !conn.Capabilities().Supports(capability.OFSDelta)
+	useRefDeltas := !sess.Capabilities().Supports(capability.OFSDelta)
 	rd, wr := io.Pipe()
 
 	config, err := s.Config()
@@ -1419,7 +1401,7 @@ func pushHashes(
 		close(done)
 	}
 
-	if err := conn.Push(ctx, req); err != nil {
+	if err := sess.Push(ctx, s, req); err != nil {
 		// close the pipe to unlock encode write
 		_ = rd.Close()
 		return err

--- a/repository.go
+++ b/repository.go
@@ -1106,16 +1106,13 @@ func (r *Repository) clone(ctx context.Context, o *CloneOptions) error {
 	}
 
 	ref, err := r.fetchAndUpdateReferences(ctx, &FetchOptions{
-		RefSpecs:        c.Fetch,
-		Depth:           o.Depth,
-		Auth:            o.Auth,
-		Progress:        o.Progress,
-		Tags:            o.Tags,
-		RemoteName:      o.RemoteName,
-		InsecureSkipTLS: o.InsecureSkipTLS,
-		CABundle:        o.CABundle,
-		ProxyOptions:    o.ProxyOptions,
-		Filter:          o.Filter,
+		RefSpecs:      c.Fetch,
+		Depth:         o.Depth,
+		ClientOptions: o.ClientOptions,
+		Progress:      o.Progress,
+		Tags:          o.Tags,
+		RemoteName:    o.RemoteName,
+		Filter:        o.Filter,
 	}, o.ReferenceName)
 
 	hr, err1 := r.Storer.Reference(plumbing.HEAD)
@@ -1159,7 +1156,7 @@ func (r *Repository) clone(ctx context.Context, o *CloneOptions) error {
 					}
 					return 0
 				}(),
-				Auth: o.Auth,
+				ClientOptions: o.ClientOptions,
 			}); err != nil {
 				return err
 			}

--- a/submodule.go
+++ b/submodule.go
@@ -135,7 +135,7 @@ func (s *Submodule) Repository() (*Repository, error) {
 		return nil, err
 	}
 
-	moduleEndpoint, err := transport.NewEndpoint(s.c.URL)
+	moduleEndpoint, err := transport.ParseURL(s.c.URL)
 	if err != nil {
 		return nil, err
 	}
@@ -146,7 +146,7 @@ func (s *Submodule) Repository() (*Repository, error) {
 			return nil, err
 		}
 
-		rootEndpoint, err := transport.NewEndpoint(remotes[0].c.URLs[0])
+		rootEndpoint, err := transport.ParseURL(remotes[0].c.URLs[0])
 		if err != nil {
 			return nil, err
 		}
@@ -245,7 +245,7 @@ func (s *Submodule) fetchAndCheckout(
 	ctx context.Context, r *Repository, o *SubmoduleUpdateOptions, hash plumbing.Hash,
 ) error {
 	if !o.NoFetch {
-		err := r.FetchContext(ctx, &FetchOptions{Auth: o.Auth, Depth: o.Depth})
+		err := r.FetchContext(ctx, &FetchOptions{ClientOptions: o.ClientOptions, Depth: o.Depth})
 		if err != nil && !errors.Is(err, NoErrAlreadyUpToDate) {
 			return err
 		}
@@ -265,7 +265,7 @@ func (s *Submodule) fetchAndCheckout(
 			refSpec := config.RefSpec("+" + hash.String() + ":" + hash.String())
 
 			err := r.FetchContext(ctx, &FetchOptions{
-				Auth:     o.Auth,
+				ClientOptions: o.ClientOptions,
 				RefSpecs: []config.RefSpec{refSpec},
 				Depth:    o.Depth,
 			})


### PR DESCRIPTION
## Summary

Rewire all top-level callers (`remote.go`, `repository.go`, `submodule.go`, `options.go`, `transport.go`) to use the new `plumbing/transport` and `plumbing/client` APIs.

## What changed

**options.go:**
- Replace `Auth transport.AuthMethod`, `InsecureSkipTLS bool`, `CABundle []byte`, `ProxyOptions transport.ProxyOptions` fields with a single `ClientOptions []client.Option` on all option structs (`CloneOptions`, `PullOptions`, `FetchOptions`, `PushOptions`, `SubmoduleUpdateOptions`, `ListOptions`)
- Users now pass `client.WithSSHAuth(...)`, `client.WithHTTPAuth(...)`, `client.WithInsecureSkipTLS()`, `client.WithCABundle(...)`, `client.WithProxyURL(...)`, etc. via `ClientOptions`

**remote.go:**
- Replace `newClient()` to use `client.New()` + `transport.ParseURL()` instead of `transport.Get()` + `transport.NewEndpoint()`
- Collapse `Transport.NewSession()` + `Session.Handshake()` into single `client.Handshake(ctx, req)` call
- Pass `storage.Storer` to `Session.Fetch()` and `Session.Push()` (new signature)
- Rename `conn` (old `Connection`) to `sess` (new `Session`) throughout

**repository.go:**
- Update `FetchOptions` and `SubmoduleUpdateOptions` construction to use `ClientOptions`

**submodule.go:**
- Replace `transport.NewEndpoint()` with `transport.ParseURL()` (returns `*url.URL`)
- Update option construction to use `ClientOptions`

**4 files changed**, 54 insertions, 103 deletions.

## Dependencies

- [#5](https://github.com/aymanbagabas/go-git/pull/5) (PR 1: core)
- [#6](https://github.com/aymanbagabas/go-git/pull/6) (PR 2: test suites)
- [#7](https://github.com/aymanbagabas/go-git/pull/7) (PR 3: SSH)
- [#8](https://github.com/aymanbagabas/go-git/pull/8) (PR 4: HTTP)
- [#9](https://github.com/aymanbagabas/go-git/pull/9) (PR 5: Git)
- [#10](https://github.com/aymanbagabas/go-git/pull/10) (PR 6: file)
- [#11](https://github.com/aymanbagabas/go-git/pull/11) (PR 7: client)

## PR Stack

This is **PR 8 of 11** in the transport migration stack.

| # | PR | Description | Status |
|---|-----|-------------|--------|
| 1 | [#5](https://github.com/aymanbagabas/go-git/pull/5) | Replace `plumbing/transport` core | |
| 2 | [#6](https://github.com/aymanbagabas/go-git/pull/6) | Replace `internal/transport/test` suites | |
| 3 | [#7](https://github.com/aymanbagabas/go-git/pull/7) | Replace `plumbing/transport/ssh` | |
| 4 | [#8](https://github.com/aymanbagabas/go-git/pull/8) | Replace `plumbing/transport/http` | |
| 5 | [#9](https://github.com/aymanbagabas/go-git/pull/9) | Replace `plumbing/transport/git` | |
| 6 | [#10](https://github.com/aymanbagabas/go-git/pull/10) | Replace `plumbing/transport/file` | |
| 7 | [#11](https://github.com/aymanbagabas/go-git/pull/11) | Add `plumbing/client` | |
| 8 | [#12](https://github.com/aymanbagabas/go-git/pull/12) | Rewire callers | |
| 9 | [#13](https://github.com/aymanbagabas/go-git/pull/13) | Rewire server/backends | |
| 10 | [#14](https://github.com/aymanbagabas/go-git/pull/14) | Update examples | |
| 11 | [#15](https://github.com/aymanbagabas/go-git/pull/15) | Fix build errors | |