### PR TITLE
PR 9: internal: server, backend: rewire to new transport API

### DIFF
--- a/backend/git/git.go
+++ b/backend/git/git.go
@@ -59,7 +59,7 @@ func (b *Backend) ServeTCP(ctx context.Context, c io.ReadWriteCloser, req *packp
 	// Ensure we close the connection when we're done.
 	defer func() { _ = c.Close() }()
 
-	svc := transport.Service(req.RequestCommand)
+	svc := string(req.RequestCommand)
 	switch {
 	case svc == transport.UploadPackService && b.UploadPack,
 		svc == transport.ReceivePackService && b.ReceivePack:
@@ -80,7 +80,7 @@ func (b *Backend) ServeTCP(ctx context.Context, c io.ReadWriteCloser, req *packp
 		return
 	}
 
-	ep, err := transport.NewEndpoint(url)
+	ep, err := transport.ParseURL(url)
 	if err != nil {
 		_ = renderError(wc, fmt.Errorf("%w: %w", transport.ErrRepositoryNotFound, err))
 		return

--- a/backend/http/http.go
+++ b/backend/http/http.go
@@ -25,7 +25,7 @@ type service struct {
 	pattern *regexp.Regexp
 	method  string
 	handler http.HandlerFunc
-	svc     transport.Service
+	svc     string
 }
 
 var services = []service{
@@ -90,7 +90,7 @@ func (b *Backend) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 			repo := strings.TrimPrefix(m[1], "/")
 			file := strings.Replace(urlPath, repo+"/", "", 1)
-			ep, err := transport.NewEndpoint(repo)
+			ep, err := transport.ParseURL(repo)
 			if err != nil {
 				logf(b.ErrorLog, "error creating endpoint: %v", err)
 				renderStatusError(w, http.StatusBadRequest)
@@ -135,7 +135,7 @@ func serviceRPC(w http.ResponseWriter, r *http.Request) {
 		renderStatusError(w, http.StatusInternalServerError)
 		return
 	}
-	svc, ok := ctx.Value(contextKey("service")).(transport.Service)
+	svc, ok := ctx.Value(contextKey("service")).(string)
 	if !ok {
 		renderStatusError(w, http.StatusInternalServerError)
 		return
@@ -148,13 +148,13 @@ func serviceRPC(w http.ResponseWriter, r *http.Request) {
 	version := r.Header.Get("Git-Protocol")
 	contentType := strings.ToLower(strings.TrimSpace(r.Header.Get("Content-Type")))
 
-	expectedContentType := strings.ToLower(fmt.Sprintf("application/x-git-%s-request", svc.Name()))
+	expectedContentType := strings.ToLower(fmt.Sprintf("application/x-git-%s-request", transport.ServiceName(svc)))
 	if contentType != expectedContentType {
 		renderStatusError(w, http.StatusForbidden)
 		return
 	}
 
-	w.Header().Set("Content-Type", fmt.Sprintf("application/x-git-%s-result", svc.Name()))
+	w.Header().Set("Content-Type", fmt.Sprintf("application/x-git-%s-result", transport.ServiceName(svc)))
 	w.Header().Set("Connection", "Keep-Alive")
 	w.Header().Set("Transfer-Encoding", "chunked")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
@@ -193,7 +193,7 @@ func serviceRPC(w http.ResponseWriter, r *http.Request) {
 			})
 	default:
 		// TODO: Support git-upload-archive
-		logf(errorLog, "unknown service: %s", svc.Name())
+		logf(errorLog, "unknown service: %s", transport.ServiceName(svc))
 		renderStatusError(w, http.StatusNotFound)
 		return
 	}
@@ -272,12 +272,12 @@ func getInfoRefs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	service := transport.Service(r.URL.Query().Get("service"))
+	service := string(r.URL.Query().Get("service"))
 	version := r.Header.Get("Git-Protocol")
 
 	if service != "" {
 		hdrNocache(w)
-		w.Header().Set("Content-Type", fmt.Sprintf("application/x-git-%s-advertisement", service.Name()))
+		w.Header().Set("Content-Type", fmt.Sprintf("application/x-git-%s-advertisement", transport.ServiceName(service)))
 
 		var err error
 		switch service {

--- a/internal/server/loader.go
+++ b/internal/server/loader.go
@@ -3,6 +3,7 @@ package server
 
 import (
 	"fmt"
+	"net/url"
 	"testing"
 
 	"github.com/go-git/go-billy/v6"
@@ -19,7 +20,7 @@ type fixturesLoader struct {
 
 var _ transport.Loader = &fixturesLoader{}
 
-func (f *fixturesLoader) Load(_ *transport.Endpoint) (storage.Storer, error) {
+func (f *fixturesLoader) Load(_ *url.URL) (storage.Storer, error) {
 	if f.dot == nil {
 		return nil, fmt.Errorf("cannot load endpoint: fixture not set")
 	}


### PR DESCRIPTION
## Summary

Update server and backend packages for the new `plumbing/transport` API.

## What changed

**backend/git/git.go:**
- Replace `transport.Service()` type cast with `string()`
- Replace `transport.NewEndpoint()` with `transport.ParseURL()`

**backend/http/http.go:**
- Replace `transport.Service` type with `string` throughout
- Replace `svc.Name()` / `service.Name()` method calls with `transport.ServiceName()`
- Replace `transport.NewEndpoint()` with `transport.ParseURL()`

**internal/server/loader.go:**
- Update `fixturesLoader.Load()` parameter from `*transport.Endpoint` to `*url.URL`

**3 files changed**, 12 insertions, 11 deletions.

## Dependencies

- All PRs 1–8

## PR Stack

This is **PR 9 of 11** in the transport migration stack.

| # | PR | Description | Status |
|---|-----|-------------|--------|
| 1 | [#5](https://github.com/aymanbagabas/go-git/pull/5) | Replace `plumbing/transport` core | |
| 2 | [#6](https://github.com/aymanbagabas/go-git/pull/6) | Replace `internal/transport/test` suites | |
| 3 | [#7](https://github.com/aymanbagabas/go-git/pull/7) | Replace `plumbing/transport/ssh` | |
| 4 | [#8](https://github.com/aymanbagabas/go-git/pull/8) | Replace `plumbing/transport/http` | |
| 5 | [#9](https://github.com/aymanbagabas/go-git/pull/9) | Replace `plumbing/transport/git` | |
| 6 | [#10](https://github.com/aymanbagabas/go-git/pull/10) | Replace `plumbing/transport/file` | |
| 7 | [#11](https://github.com/aymanbagabas/go-git/pull/11) | Add `plumbing/client` | |
| 8 | [#12](https://github.com/aymanbagabas/go-git/pull/12) | Rewire callers | |
| 9 | [#13](https://github.com/aymanbagabas/go-git/pull/13) | Rewire server/backends | |
| 10 | [#14](https://github.com/aymanbagabas/go-git/pull/14) | Update examples | |
| 11 | [#15](https://github.com/aymanbagabas/go-git/pull/15) | Fix build errors | |