### PR TITLE
PR 13: plumbing: transport, add missing trace logs for ssh auth and known_hosts loading

### DIFF
--- a/backend/http.go
+++ b/backend/http.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"path"
 	"regexp"
 	"strings"
 	"time"
@@ -95,6 +96,12 @@ func (b *Backend) handleServiceRPC(w http.ResponseWriter, r *http.Request, repo,
 		return
 	}
 
+	if s := path.Base(ep.Path); s != svc {
+		b.logf("invalid service requested: %q", s)
+		renderStatusError(w, http.StatusNotFound)
+		return
+	}
+
 	frw := &flushResponseWriter{ResponseWriter: w, log: b.ErrorLog, chunkSize: defaultChunkSize}
 	if err := b.Serve(r.Context(), reader, frw, &Request{
 		URL:          ep,
@@ -113,6 +120,12 @@ func (b *Backend) handleInfoRefs(w http.ResponseWriter, r *http.Request, repo, f
 	if service == "" {
 		hdrNocache(w)
 		b.handleDumbSendFile(w, r, repo, file, "text/plain; charset=utf-8")
+		return
+	}
+
+	if service != transport.UploadPackService && service != transport.ReceivePackService {
+		b.logf("unsupported service requested: %q", service)
+		renderStatusError(w, http.StatusNotFound)
 		return
 	}
 

--- a/backend/http.go
+++ b/backend/http.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"path"
 	"regexp"
 	"strings"
 	"time"
@@ -96,14 +95,7 @@ func (b *Backend) handleServiceRPC(w http.ResponseWriter, r *http.Request, repo,
 		return
 	}
 
-	service := path.Base(ep.Path)
-	if service != svc {
-		b.logf("invalid service requested: %q", service)
-		renderStatusError(w, http.StatusNotFound)
-		return
-	}
-
-	if !b.requireReceivePackAuth(w, r, service) {
+	if !b.requireReceivePackAuth(w, r, svc) {
 		return
 	}
 

--- a/backend/http.go
+++ b/backend/http.go
@@ -96,9 +96,14 @@ func (b *Backend) handleServiceRPC(w http.ResponseWriter, r *http.Request, repo,
 		return
 	}
 
-	if s := path.Base(ep.Path); s != svc {
-		b.logf("invalid service requested: %q", s)
+	service := path.Base(ep.Path)
+	if service != svc {
+		b.logf("invalid service requested: %q", service)
 		renderStatusError(w, http.StatusNotFound)
+		return
+	}
+
+	if !b.requireReceivePackAuth(w, r, service) {
 		return
 	}
 
@@ -126,6 +131,10 @@ func (b *Backend) handleInfoRefs(w http.ResponseWriter, r *http.Request, repo, f
 	if service != transport.UploadPackService && service != transport.ReceivePackService {
 		b.logf("unsupported service requested: %q", service)
 		renderStatusError(w, http.StatusNotFound)
+		return
+	}
+
+	if !b.requireReceivePackAuth(w, r, service) {
 		return
 	}
 
@@ -231,6 +240,16 @@ func (b *Backend) handleDumbSendFile(w http.ResponseWriter, _ *http.Request, rep
 		renderStatusError(w, http.StatusInternalServerError)
 		return
 	}
+}
+
+func (b *Backend) requireReceivePackAuth(w http.ResponseWriter, r *http.Request, service string) bool {
+	// For receive-pack, require authentication as a basic sanity check.
+	if service == transport.ReceivePackService && strings.TrimSpace(r.Header.Get("Authorization")) == "" {
+		b.logf("missing Authorization header for receive-pack service")
+		renderStatusError(w, http.StatusUnauthorized)
+		return false
+	}
+	return true
 }
 
 func renderStatusError(w http.ResponseWriter, code int) {

--- a/backend/http_test.go
+++ b/backend/http_test.go
@@ -170,3 +170,27 @@ func TestSmartInfoRefsObjectFormat(t *testing.T) {
 		})
 	}
 }
+
+func TestUnsupportedService(t *testing.T) {
+	t.Parallel()
+
+	h := New(&fixturesLoader{t})
+
+	req := httptest.NewRequest("GET", "/basic.git/info/refs?service=invalid-service", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	res := w.Result()
+	require.Equal(t, 404, res.StatusCode)
+}
+
+func TestInvalidService(t *testing.T) {
+	t.Parallel()
+
+	h := New(&fixturesLoader{t})
+
+	req := httptest.NewRequest("POST", "/basic.git/git-your-face", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	res := w.Result()
+	require.Equal(t, 404, res.StatusCode)
+}

--- a/plumbing/client/client.go
+++ b/plumbing/client/client.go
@@ -193,7 +193,7 @@ func (c *Client) Connect(ctx context.Context, req *transport.Request) (transport
 	}
 	conn, ok := tr.(transport.Connectable)
 	if !ok {
-		return nil, transport.ErrConnectUnsupported
+		return nil, fmt.Errorf("transport for %s does not support Connect: %w", req.URL.Scheme, transport.ErrConnectUnsupported)
 	}
 	return conn.Connect(ctx, req)
 }

--- a/plumbing/client/client.go
+++ b/plumbing/client/client.go
@@ -147,6 +147,9 @@ func WithLoader(l transport.Loader) Option {
 // This overrides any built-in transport for that scheme.
 func WithTransport(scheme string, tr transport.Transport) Option {
 	return func(o *options) {
+		if scheme == "" || tr == nil {
+			return
+		}
 		if o.schemes == nil {
 			o.schemes = make(map[string]transport.Transport)
 		}

--- a/plumbing/client/client.go
+++ b/plumbing/client/client.go
@@ -185,13 +185,13 @@ func (c *Client) Handshake(ctx context.Context, req *transport.Request) (transpo
 
 // Connect resolves the transport for the request URL scheme and opens a
 // raw full-duplex connection. Returns ErrConnectUnsupported if the transport
-// does not implement Connectable (e.g. HTTP).
+// does not implement Connector (e.g. HTTP).
 func (c *Client) Connect(ctx context.Context, req *transport.Request) (transport.Conn, error) {
 	tr, err := c.resolve(req)
 	if err != nil {
 		return nil, err
 	}
-	conn, ok := tr.(transport.Connectable)
+	conn, ok := tr.(transport.Connector)
 	if !ok {
 		return nil, fmt.Errorf("transport for %s does not support Connect: %w", req.URL.Scheme, transport.ErrConnectUnsupported)
 	}

--- a/plumbing/client/client_test.go
+++ b/plumbing/client/client_test.go
@@ -29,7 +29,7 @@ func TestNew_BuiltinSchemes(t *testing.T) {
 	}
 }
 
-func TestNew_ConnectableSchemes(t *testing.T) {
+func TestNew_ConnectorSchemes(t *testing.T) {
 	t.Parallel()
 
 	c := New()
@@ -38,12 +38,12 @@ func TestNew_ConnectableSchemes(t *testing.T) {
 	for _, scheme := range []string{"file", "git", "ssh"} {
 		tr, err := c.Transport(scheme)
 		require.NoError(t, err)
-		_, ok := tr.(transport.Connectable)
-		assert.True(t, ok, "scheme %q should implement Connectable", scheme)
+		_, ok := tr.(transport.Connector)
+		assert.True(t, ok, "scheme %q should implement Connector", scheme)
 	}
 }
 
-func TestNew_HTTPNotConnectable(t *testing.T) {
+func TestNew_HTTPNotConnector(t *testing.T) {
 	t.Parallel()
 
 	c := New()
@@ -52,8 +52,8 @@ func TestNew_HTTPNotConnectable(t *testing.T) {
 	for _, scheme := range []string{"http", "https"} {
 		tr, err := c.Transport(scheme)
 		require.NoError(t, err)
-		_, ok := tr.(transport.Connectable)
-		assert.False(t, ok, "scheme %q should NOT implement Connectable", scheme)
+		_, ok := tr.(transport.Connector)
+		assert.False(t, ok, "scheme %q should NOT implement Connector", scheme)
 	}
 }
 

--- a/plumbing/transport/doc.go
+++ b/plumbing/transport/doc.go
@@ -3,11 +3,11 @@
 // The API separates transport capabilities from Git protocol adapters:
 //
 //   - Conn: a transport connection with independent read, write, and close
-//   - Connectable: transports that can open raw full-duplex connections
+//   - Connector: transports that can open raw full-duplex connections
 //   - Transport: transports that speak the Git pack protocol (Handshake)
 //   - Session: a connected Git protocol session (refs, fetch, push)
 //
-// Stream transports (SSH, Git TCP, file) implement both Connectable and
+// Stream transports (SSH, Git TCP, file) implement both Connector and
 // Transport. HTTP implements only Transport, handling the smart and dumb
 // HTTP protocols internally.
 package transport

--- a/plumbing/transport/file/file.go
+++ b/plumbing/transport/file/file.go
@@ -65,9 +65,9 @@ func (t *Transport) Connect(ctx context.Context, req *transport.Request) (transp
 func (t *Transport) connect(ctx context.Context, req *transport.Request) (io.Reader, *io.PipeWriter, func() error, error) {
 	var serverFn ServerFunc
 	switch req.Command {
-	case "git-upload-pack":
+	case transport.UploadPackService:
 		serverFn = t.uploadPack
-	case "git-receive-pack":
+	case transport.ReceivePackService:
 		serverFn = t.receivePack
 	default:
 		return nil, nil, nil, fmt.Errorf("%w: %s", transport.ErrCommandUnsupported, req.Command)

--- a/plumbing/transport/file/file_test.go
+++ b/plumbing/transport/file/file_test.go
@@ -95,5 +95,3 @@ func TestFileTransport_ImplementsConnector(t *testing.T) {
 	_, ok := any(tr).(transport.Connector)
 	assert.True(t, ok)
 }
-
-var _ transport.Conn = (*fileConn)(nil)

--- a/plumbing/transport/file/file_test.go
+++ b/plumbing/transport/file/file_test.go
@@ -87,12 +87,12 @@ func TestFileTransport_RepoNotFound(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestFileTransport_ImplementsConnectable(t *testing.T) {
+func TestFileTransport_ImplementsConnector(t *testing.T) {
 	t.Parallel()
 
 	tr := NewTransport(Options{})
 
-	_, ok := any(tr).(transport.Connectable)
+	_, ok := any(tr).(transport.Connector)
 	assert.True(t, ok)
 }
 

--- a/plumbing/transport/file/handshake.go
+++ b/plumbing/transport/file/handshake.go
@@ -15,4 +15,7 @@ func (t *Transport) Handshake(ctx context.Context, req *transport.Request) (tran
 	return transport.NewStreamSession(conn, req.Command)
 }
 
-var _ transport.Transport = (*Transport)(nil)
+var (
+	_ transport.Transport = (*Transport)(nil)
+	_ transport.Connector = (*Transport)(nil)
+)

--- a/plumbing/transport/git/handshake.go
+++ b/plumbing/transport/git/handshake.go
@@ -15,4 +15,7 @@ func (t *Transport) Handshake(ctx context.Context, req *transport.Request) (tran
 	return transport.NewStreamSession(conn, req.Command)
 }
 
-var _ transport.Transport = (*Transport)(nil)
+var (
+	_ transport.Transport = (*Transport)(nil)
+	_ transport.Connector = (*Transport)(nil)
+)

--- a/plumbing/transport/http/common.go
+++ b/plumbing/transport/http/common.go
@@ -85,7 +85,7 @@ var safeHeaders = map[string]struct{}{
 	"Host":              {},
 	"Accept":            {},
 	"Content-Type":      {},
-	"Content-Length":     {},
+	"Content-Length":    {},
 	"Cache-Control":     {},
 	"Git-Protocol":      {},
 	"Transfer-Encoding": {},

--- a/plumbing/transport/http/common.go
+++ b/plumbing/transport/http/common.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	transport "github.com/go-git/go-git/v6/plumbing/transport"
+	"github.com/go-git/go-git/v6/utils/trace"
 )
 
 // Err represents an HTTP error response.
@@ -79,11 +80,57 @@ func applyRedirect(resp *http.Response, baseURL *url.URL) *url.URL {
 	return &redirected
 }
 
+var safeHeaders = map[string]struct{}{
+	"User-Agent":        {},
+	"Host":              {},
+	"Accept":            {},
+	"Content-Type":      {},
+	"Content-Length":     {},
+	"Cache-Control":     {},
+	"Git-Protocol":      {},
+	"Transfer-Encoding": {},
+	"Content-Encoding":  {},
+}
+
+func filterHeaders(h http.Header) http.Header {
+	filtered := make(http.Header)
+	for key, values := range h {
+		if _, ok := safeHeaders[http.CanonicalHeaderKey(key)]; ok {
+			filtered[key] = values
+		}
+	}
+	return filtered
+}
+
+func redactedURL(u *url.URL) string {
+	if u == nil {
+		return ""
+	}
+	if u.User == nil {
+		return u.String()
+	}
+	if _, hasPassword := u.User.Password(); !hasPassword {
+		return u.String()
+	}
+	redacted := *u
+	redacted.User = url.UserPassword(u.User.Username(), "REDACTED")
+	return redacted.String()
+}
+
 // doRequest performs an HTTP request and returns a typed error on failure.
 func doRequest(client *http.Client, req *http.Request) (*http.Response, error) {
+	traceHTTP := trace.HTTP.Enabled()
+	if traceHTTP {
+		trace.HTTP.Printf("requesting %s %s %v", req.Method, redactedURL(req.URL), filterHeaders(req.Header))
+	}
+
 	res, err := client.Do(req)
 	if err != nil {
 		return nil, err
+	}
+
+	if traceHTTP {
+		trace.HTTP.Printf("response %s %s %s %v", res.Proto, res.Status, redactedURL(res.Request.URL), filterHeaders(res.Header))
 	}
 
 	if res.StatusCode >= http.StatusOK && res.StatusCode < http.StatusMultipleChoices {

--- a/plumbing/transport/http/handshake.go
+++ b/plumbing/transport/http/handshake.go
@@ -150,6 +150,8 @@ func handshakeDumb(resp *http.Response, req *transport.Request, client *http.Cli
 
 // --- smart HTTP pack session ---
 
+var _ transport.Session = (*smartPackSession)(nil)
+
 type smartPackSession struct {
 	client     *http.Client
 	baseURL    *url.URL
@@ -253,6 +255,8 @@ func (r *httpRequester) doPost() error {
 }
 
 // --- dumb HTTP pack session ---
+
+var _ transport.Session = (*dumbPackSession)(nil)
 
 type dumbPackSession struct {
 	client     *http.Client

--- a/plumbing/transport/http/handshake.go
+++ b/plumbing/transport/http/handshake.go
@@ -56,7 +56,7 @@ func (t *Transport) Handshake(ctx context.Context, req *transport.Request) (tran
 	}
 
 	client := t.resolveClient()
-	resp, err := client.Do(httpReq)
+	resp, err := doRequest(client, httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("http transport: %w", err)
 	}
@@ -241,7 +241,7 @@ func (r *httpRequester) doPost() error {
 			return err
 		}
 	}
-	r.resp, err = r.session.client.Do(httpReq)
+	r.resp, err = doRequest(r.session.client, httpReq)
 	if err != nil {
 		return fmt.Errorf("http transport: %w", err)
 	}

--- a/plumbing/transport/http/http.go
+++ b/plumbing/transport/http/http.go
@@ -5,6 +5,8 @@ import (
 	"crypto/tls"
 	"net/http"
 	"net/url"
+
+	"github.com/go-git/go-git/v6/plumbing/transport"
 )
 
 // Options configures the HTTP transport.
@@ -38,6 +40,8 @@ type Options struct {
 type Transport struct {
 	opts Options
 }
+
+var _ transport.Transport = (*Transport)(nil)
 
 // NewTransport creates an HTTP transport with the given options.
 func NewTransport(opts Options) *Transport {

--- a/plumbing/transport/http/proxy_test.go
+++ b/plumbing/transport/http/proxy_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"embed"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"net"
@@ -33,13 +34,14 @@ type proxySuite struct {
 
 func (s *proxySuite) TestAdvertisedReferencesHTTP() {
 	var proxiedRequests int32
-	proxy := newTestProxy(&proxiedRequests)
+	proxy := newTestProxy(&proxiedRequests, "user", "pass")
 	httpProxyAddr := setupProxyServer(s.T(), proxy, false, true)
 
 	base, addr := setupSmartServer(s.T())
 	prepareRepo(s.T(), fixtures.Basic().One(), base, "basic.git")
 
 	proxyURL, err := url.Parse(httpProxyAddr)
+	proxyURL.User = url.UserPassword("user", "pass")
 	s.Require().NoError(err)
 	tr := NewTransport(Options{
 		HTTPProxy: http.ProxyURL(proxyURL),
@@ -63,10 +65,11 @@ func (s *proxySuite) TestAdvertisedReferencesHTTP() {
 
 func (s *proxySuite) TestAdvertisedReferencesHTTPS() {
 	var proxiedRequests int32
-	proxy := newTestProxy(&proxiedRequests)
+	proxy := newTestProxy(&proxiedRequests, "user", "pass")
 	httpsProxyAddr := setupProxyServer(s.T(), proxy, true, true)
 
 	proxyURL, err := url.Parse(httpsProxyAddr)
+	proxyURL.User = url.UserPassword("user", "pass")
 	s.Require().NoError(err)
 	tr := NewTransport(Options{
 		HTTPProxy: http.ProxyURL(proxyURL),
@@ -157,13 +160,21 @@ func setupProxyServer(t testing.TB, handler http.Handler, isTLS, schemaAddr bool
 
 type testProxy struct {
 	proxiedRequests *int32
+	username       string
+	password       string
 }
 
-func newTestProxy(proxiedRequests *int32) *testProxy {
-	return &testProxy{proxiedRequests: proxiedRequests}
+func newTestProxy(proxiedRequests *int32, username, password string) *testProxy {
+	return &testProxy{proxiedRequests: proxiedRequests, username: username, password: password}
 }
 
 func (p *testProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	user, pass, _ := parseBasicAuth(r.Header.Get("Proxy-Authorization"))
+	if user != p.username || pass != p.password {
+		http.Error(w, "Proxy Authentication Required", http.StatusProxyAuthRequired)
+		return
+	}
+
 	if r.Method == http.MethodConnect {
 		p.handleConnect(w, r)
 	} else {
@@ -252,4 +263,21 @@ func (p *testProxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	w.WriteHeader(resp.StatusCode)
 	_, _ = io.Copy(w, resp.Body)
+}
+
+func parseBasicAuth(auth string) (username, password string, ok bool) {
+	const prefix = "Basic "
+	if len(auth) < len(prefix) || !strings.EqualFold(auth[:len(prefix)], prefix) {
+		return "", "", false
+	}
+	c, err := base64.StdEncoding.DecodeString(auth[len(prefix):])
+	if err != nil {
+		return "", "", false
+	}
+	cs := string(c)
+	username, password, ok = strings.Cut(cs, ":")
+	if !ok {
+		return "", "", false
+	}
+	return username, password, true
 }

--- a/plumbing/transport/http/proxy_test.go
+++ b/plumbing/transport/http/proxy_test.go
@@ -160,8 +160,8 @@ func setupProxyServer(t testing.TB, handler http.Handler, isTLS, schemaAddr bool
 
 type testProxy struct {
 	proxiedRequests *int32
-	username       string
-	password       string
+	username        string
+	password        string
 }
 
 func newTestProxy(proxiedRequests *int32, username, password string) *testProxy {

--- a/plumbing/transport/ssh/auth.go
+++ b/plumbing/transport/ssh/auth.go
@@ -218,13 +218,13 @@ func newKnownHostsDb(files ...string) (*knownhosts.HostKeyDB, error) {
 		}
 	}
 
-	trace.SSH.Printf("ssh: known_hosts sources %s", files)
+	trace.SSH.Printf("ssh: known_hosts sources %v", files)
 
 	files, err := filterKnownHostsFiles(files...)
 	if err != nil {
 		return nil, err
 	}
-	trace.SSH.Printf("ssh: filtered known_hosts sources %s", files)
+	trace.SSH.Printf("ssh: filtered known_hosts sources %v", files)
 
 	return knownhosts.NewDB(files...)
 }

--- a/plumbing/transport/ssh/auth.go
+++ b/plumbing/transport/ssh/auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -13,6 +14,16 @@ import (
 	transport "github.com/go-git/go-git/v6/plumbing/transport"
 	"github.com/go-git/go-git/v6/plumbing/transport/ssh/knownhosts"
 	"github.com/go-git/go-git/v6/plumbing/transport/ssh/sshagent"
+	"github.com/go-git/go-git/v6/utils/trace"
+)
+
+// The names of the auth method implementations.
+const (
+	keyboardInteractiveName = "ssh-keyboard-interactive"
+	passwordName            = "ssh-password"
+	passwordCallbackName    = "ssh-password-callback"
+	publicKeysName          = "ssh-public-keys"
+	publicKeysCallbackName  = "ssh-public-key-callback"
 )
 
 // HostKeyCallbackHelper provides common functionality to configure
@@ -34,8 +45,15 @@ func (m *HostKeyCallbackHelper) SetHostKeyCallback(cfg *gossh.ClientConfig) (*go
 		m.HostKeyCallback = db.HostKeyCallback()
 	}
 
-	cfg.HostKeyCallback = m.HostKeyCallback
+	cfg.HostKeyCallback = m.traceHostKeyCallback
 	return cfg, nil
+}
+
+func (m *HostKeyCallbackHelper) traceHostKeyCallback(hostname string, remote net.Addr, key gossh.PublicKey) error {
+	trace.SSH.Printf(
+		`ssh: hostkey callback hostname=%s remote=%s pubkey="%s %s"`,
+		hostname, remote, key.Type(), gossh.FingerprintSHA256(key))
+	return m.HostKeyCallback(hostname, remote, key)
 }
 
 // Password implements SSH password authentication.
@@ -47,6 +65,7 @@ type Password struct {
 
 // ClientConfig returns the ssh.ClientConfig for password authentication.
 func (a *Password) ClientConfig(_ context.Context, _ *transport.Request) (*gossh.ClientConfig, error) {
+	trace.SSH.Printf("ssh: %s user=%s", passwordName, a.User)
 	return a.SetHostKeyCallback(&gossh.ClientConfig{
 		User: a.User,
 		Auth: []gossh.AuthMethod{gossh.Password(a.Password)},
@@ -63,6 +82,7 @@ type PasswordCallback struct {
 
 // ClientConfig returns the ssh.ClientConfig for password callback authentication.
 func (a *PasswordCallback) ClientConfig(_ context.Context, _ *transport.Request) (*gossh.ClientConfig, error) {
+	trace.SSH.Printf("ssh: %s user=%s", passwordCallbackName, a.User)
 	return a.SetHostKeyCallback(&gossh.ClientConfig{
 		User: a.User,
 		Auth: []gossh.AuthMethod{gossh.PasswordCallback(a.Callback)},
@@ -104,6 +124,9 @@ func NewPublicKeysFromFile(user, pemFile, password string) (*PublicKeys, error) 
 
 // ClientConfig returns the ssh.ClientConfig for public key authentication.
 func (a *PublicKeys) ClientConfig(_ context.Context, _ *transport.Request) (*gossh.ClientConfig, error) {
+	trace.SSH.Printf("ssh: %s user=%s signer=\"%s %s\"", publicKeysName, a.User,
+		a.Signer.PublicKey().Type(),
+		gossh.FingerprintSHA256(a.Signer.PublicKey()))
 	return a.SetHostKeyCallback(&gossh.ClientConfig{
 		User: a.User,
 		Auth: []gossh.AuthMethod{gossh.PublicKeys(a.Signer)},
@@ -143,9 +166,10 @@ func NewSSHAgentAuth(u string) (*PublicKeysCallback, error) {
 
 // ClientConfig returns the ssh.ClientConfig for public key callback authentication.
 func (a *PublicKeysCallback) ClientConfig(_ context.Context, _ *transport.Request) (*gossh.ClientConfig, error) {
+	trace.SSH.Printf("ssh: %s user=%s", publicKeysCallbackName, a.User)
 	return a.SetHostKeyCallback(&gossh.ClientConfig{
 		User: a.User,
-		Auth: []gossh.AuthMethod{gossh.PublicKeysCallback(a.Callback)},
+		Auth: []gossh.AuthMethod{tracePublicKeysCallback(a.Callback)},
 	})
 }
 
@@ -159,6 +183,7 @@ type KeyboardInteractive struct {
 
 // ClientConfig returns the ssh.ClientConfig for keyboard-interactive authentication.
 func (a *KeyboardInteractive) ClientConfig(_ context.Context, _ *transport.Request) (*gossh.ClientConfig, error) {
+	trace.SSH.Printf("ssh: %s user=%s", keyboardInteractiveName, a.User)
 	return a.SetHostKeyCallback(&gossh.ClientConfig{
 		User: a.User,
 		Auth: []gossh.AuthMethod{a.Challenge},
@@ -193,16 +218,21 @@ func newKnownHostsDb(files ...string) (*knownhosts.HostKeyDB, error) {
 		}
 	}
 
+	trace.SSH.Printf("ssh: known_hosts sources %s", files)
+
 	files, err := filterKnownHostsFiles(files...)
 	if err != nil {
 		return nil, err
 	}
+	trace.SSH.Printf("ssh: filtered known_hosts sources %s", files)
+
 	return knownhosts.NewDB(files...)
 }
 
 func getDefaultKnownHostsFiles() ([]string, error) {
 	files := filepath.SplitList(os.Getenv("SSH_KNOWN_HOSTS"))
 	if len(files) != 0 {
+		trace.SSH.Printf("ssh: loading known_hosts from SSH_KNOWN_HOSTS")
 		return files, nil
 	}
 
@@ -215,6 +245,25 @@ func getDefaultKnownHostsFiles() ([]string, error) {
 		filepath.Join(homeDirPath, ".ssh", "known_hosts"),
 		"/etc/ssh/ssh_known_hosts",
 	}, nil
+}
+
+func tracePublicKeysCallback(getSigners func() ([]gossh.Signer, error)) gossh.AuthMethod {
+	signers, err := getSigners()
+	if err != nil {
+		trace.SSH.Printf("ssh: error calling getSigners: %v", err)
+	}
+	if len(signers) == 0 {
+		trace.SSH.Printf("ssh: no signers found")
+	}
+	for _, s := range signers {
+		trace.SSH.Printf("ssh: found key: %s %s", s.PublicKey().Type(),
+			gossh.FingerprintSHA256(s.PublicKey()))
+	}
+
+	cb := func() ([]gossh.Signer, error) {
+		return signers, err
+	}
+	return gossh.PublicKeysCallback(cb)
 }
 
 func filterKnownHostsFiles(files ...string) ([]string, error) {
@@ -242,8 +291,10 @@ func username() (string, error) {
 	var u string
 	if current, err := user.Current(); err == nil {
 		u = current.Username
+		trace.SSH.Printf("ssh: Falling back to current user name %q", u)
 	} else {
 		u = os.Getenv("USER")
+		trace.SSH.Printf("ssh: Falling back to environment variable USER %q", u)
 	}
 
 	if u == "" {

--- a/plumbing/transport/ssh/auth_extended_test.go
+++ b/plumbing/transport/ssh/auth_extended_test.go
@@ -1,6 +1,7 @@
 package ssh
 
 import (
+	"context"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -107,7 +108,9 @@ Host github.com
 		req := &transport.Request{
 			URL: mustParseURL("ssh://git@github.com/foo/bar.git"),
 		}
-		assert.Equal(t, "foo.local:42", tr.resolveHostWithPort(req))
+		hostPort, err := tr.resolveHostWithPort(t.Context(), req)
+		assert.NoError(t, err)
+		assert.Equal(t, "foo.local:42", hostPort)
 	})
 
 	t.Run("Default", func(t *testing.T) {
@@ -117,7 +120,9 @@ Host github.com
 		req := &transport.Request{
 			URL: mustParseURL("ssh://git@github.com/foo/bar.git"),
 		}
-		assert.Equal(t, "github.com:22", tr.resolveHostWithPort(req))
+		hostPort, err := tr.resolveHostWithPort(t.Context(), req)
+		assert.NoError(t, err)
+		assert.Equal(t, "github.com:22", hostPort)
 	})
 
 	t.Run("Wildcard", func(t *testing.T) {
@@ -130,7 +135,9 @@ Host *
 		req := &transport.Request{
 			URL: mustParseURL("ssh://git@github.com/foo/bar.git"),
 		}
-		assert.Equal(t, "github.com:42", tr.resolveHostWithPort(req))
+		hostPort, err := tr.resolveHostWithPort(t.Context(), req)
+		assert.NoError(t, err)
+		assert.Equal(t, "github.com:42", hostPort)
 	})
 }
 
@@ -154,7 +161,11 @@ func newTransportWithConfig(t *testing.T, content string) *Transport {
 	require.NoError(t, os.WriteFile(f, []byte(content), 0o644))
 	us := &ssh_config.UserSettings{}
 	us.ConfigFinder(func() string { return f })
-	return NewTransport(Options{UserSettings: us})
+	return NewTransport(Options{
+		UserSettings: func(context.Context, *transport.Request) (*ssh_config.UserSettings, error) {
+			return us, nil
+		},
+	})
 }
 
 func mustParseURL(s string) *url.URL {

--- a/plumbing/transport/ssh/handshake.go
+++ b/plumbing/transport/ssh/handshake.go
@@ -15,4 +15,7 @@ func (t *Transport) Handshake(ctx context.Context, req *transport.Request) (tran
 	return transport.NewStreamSession(conn, req.Command)
 }
 
-var _ transport.Transport = (*Transport)(nil)
+var (
+	_ transport.Transport = (*Transport)(nil)
+	_ transport.Connector = (*Transport)(nil)
+)

--- a/plumbing/transport/ssh/ssh.go
+++ b/plumbing/transport/ssh/ssh.go
@@ -91,7 +91,7 @@ func (t *Transport) connect(ctx context.Context, req *transport.Request) (*sshCo
 		config.HostKeyAlgorithms = db.HostKeyAlgorithms(hostWithPort)
 	}
 
-	trace.SSH.Printf("ssh: host key algorithms %s", config.HostKeyAlgorithms)
+	trace.SSH.Printf("ssh: host key algorithms %s", strings.Join(config.HostKeyAlgorithms, ", "))
 
 	client, err := t.dial(ctx, "tcp", hostWithPort, config)
 	if err != nil {

--- a/plumbing/transport/ssh/ssh.go
+++ b/plumbing/transport/ssh/ssh.go
@@ -56,7 +56,7 @@ func NewTransport(opts Options) *Transport {
 	return &Transport{opts: opts}
 }
 
-// Connect implements transport.Connectable.
+// Connect implements transport.Connector.
 func (t *Transport) Connect(ctx context.Context, req *transport.Request) (transport.Conn, error) {
 	conn, err := t.connect(ctx, req)
 	if err != nil {

--- a/plumbing/transport/ssh/ssh.go
+++ b/plumbing/transport/ssh/ssh.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/go-git/go-git/v6/plumbing/transport"
 	"github.com/go-git/go-git/v6/utils/ioutil"
+	"github.com/go-git/go-git/v6/utils/trace"
 )
 
 // DefaultPort is the default port for the SSH protocol.
@@ -86,6 +87,8 @@ func (t *Transport) connect(ctx context.Context, req *transport.Request) (*sshCo
 		}
 		config.HostKeyAlgorithms = db.HostKeyAlgorithms(hostWithPort)
 	}
+
+	trace.SSH.Printf("ssh: host key algorithms %s", config.HostKeyAlgorithms)
 
 	client, err := t.dial(ctx, "tcp", hostWithPort, config)
 	if err != nil {
@@ -159,6 +162,8 @@ func (t *Transport) resolveConfig(ctx context.Context, req *transport.Request) (
 		}
 	}
 
+	trace.SSH.Printf("ssh: Using default auth builder (user: %s)", username)
+
 	auth, err := NewSSHAgentAuth(username)
 	if err != nil {
 		return nil, err
@@ -184,6 +189,7 @@ func (t *Transport) dial(ctx context.Context, network, addr string, config *goss
 		if dialFn == nil {
 			dialFn = (&net.Dialer{}).DialContext
 		}
+		trace.SSH.Printf("ssh: using proxyURL for connection")
 		conn, err = t.opts.DialProxy(dialFn)(ctx, network, addr)
 	case t.opts.DialContext != nil:
 		conn, err = t.opts.DialContext(ctx, network, addr)

--- a/plumbing/transport/ssh/ssh.go
+++ b/plumbing/transport/ssh/ssh.go
@@ -41,9 +41,9 @@ type Options struct {
 	// If nil, connections are made directly.
 	DialProxy func(transport.DialContextFunc) transport.DialContextFunc
 
-	// UserSettings reads SSH configuration (Hostname, Port overrides
-	// from ~/.ssh/config). If nil, ssh_config.DefaultUserSettings is used.
-	UserSettings *ssh_config.UserSettings
+	// UserSettings provides an SSH configuration (Hostname, Port overrides
+	// from ~/.ssh/config). If nil, [ssh_config.DefaultUserSettings] is used.
+	UserSettings func(context.Context, *transport.Request) (*ssh_config.UserSettings, error)
 }
 
 // Transport implements the ssh:// transport protocol.
@@ -71,7 +71,10 @@ func (t *Transport) connect(ctx context.Context, req *transport.Request) (*sshCo
 		return nil, err
 	}
 
-	hostWithPort := t.resolveHostWithPort(req)
+	hostWithPort, err := t.resolveHostWithPort(ctx, req)
+	if err != nil {
+		return nil, err
+	}
 
 	if config.HostKeyCallback == nil {
 		db, err := newKnownHostsDb()
@@ -207,18 +210,21 @@ func (t *Transport) dial(ctx context.Context, network, addr string, config *goss
 	return gossh.NewClient(c, chans, reqs), nil
 }
 
-func (t *Transport) userSettings() *ssh_config.UserSettings {
+func (t *Transport) userSettings(ctx context.Context, req *transport.Request) (*ssh_config.UserSettings, error) {
 	if t.opts.UserSettings != nil {
-		return t.opts.UserSettings
+		return t.opts.UserSettings(ctx, req)
 	}
-	return ssh_config.DefaultUserSettings
+	return ssh_config.DefaultUserSettings, nil
 }
 
-func (t *Transport) resolveHostWithPort(req *transport.Request) string {
+func (t *Transport) resolveHostWithPort(ctx context.Context, req *transport.Request) (string, error) {
 	hostname := req.URL.Hostname()
 	port := req.URL.Port()
 
-	cfg := t.userSettings()
+	cfg, err := t.userSettings(ctx, req)
+	if err != nil {
+		return "", err
+	}
 	if configHost := cfg.Get(hostname, "Hostname"); configHost != "" {
 		hostname = configHost
 	}
@@ -234,7 +240,7 @@ func (t *Transport) resolveHostWithPort(req *transport.Request) string {
 		port = strconv.Itoa(DefaultPort)
 	}
 
-	return net.JoinHostPort(hostname, port)
+	return net.JoinHostPort(hostname, port), nil
 }
 
 type sshConn struct {

--- a/plumbing/transport/transport.go
+++ b/plumbing/transport/transport.go
@@ -22,12 +22,12 @@ type Conn interface {
 	Writer() io.WriteCloser
 }
 
-// Connectable is implemented by transports that can open a raw full-duplex
+// Connector is implemented by transports that can open a raw full-duplex
 // connection. SSH, Git TCP, and file transports implement this.
 // HTTP does not.
 //
 // Use Connect for non-pack protocols like git-upload-archive,
 // git-lfs-authenticate, git-lfs-transfer, or custom commands.
-type Connectable interface {
+type Connector interface {
 	Connect(context.Context, *Request) (Conn, error)
 }


### PR DESCRIPTION
This PR addresses comments from different previous changes.

- https://github.com/aymanbagabas/go-git/pull/7#pullrequestreview-4085320574
- https://github.com/aymanbagabas/go-git/pull/10#discussion_r3060751100
- https://github.com/aymanbagabas/go-git/pull/11#discussion_r3060714736
- https://github.com/aymanbagabas/go-git/pull/11#discussion_r3060707552
- PLACEHOLDER FOR HTTP LOST TRACING 😄 
- Make ssh_config UserSettings dynamic based on the git request
- Make backend/http return 404 on invalid and unsupported git services
- Make backend/http git-receive-pack ask for missing Authorization header
- Add lost http proxy auth validation test
- Rename `Connectable` to `Connector` following Go naming conventions