### PR TITLE
plumbing: client, add new client package

### DIFF
--- a/plumbing/client/client.go
+++ b/plumbing/client/client.go
@@ -1,0 +1,250 @@
+// Package client provides a convenience Client that resolves URL schemes
+// to transport implementations and provides Handshake/Connect methods.
+package client
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+
+	gossh "golang.org/x/crypto/ssh"
+	"golang.org/x/net/proxy"
+
+	"github.com/go-git/go-git/v6/plumbing/transport"
+	"github.com/go-git/go-git/v6/plumbing/transport/file"
+	xgit "github.com/go-git/go-git/v6/plumbing/transport/git"
+	xhttp "github.com/go-git/go-git/v6/plumbing/transport/http"
+	xssh "github.com/go-git/go-git/v6/plumbing/transport/ssh"
+)
+
+// SSHAuth is implemented by SSH authentication types whose ClientConfig
+// method can be used to produce an *ssh.ClientConfig for each request.
+type SSHAuth interface {
+	ClientConfig(context.Context, *transport.Request) (*gossh.ClientConfig, error)
+}
+
+// HTTPAuth is implemented by HTTP authentication types whose Authorizer
+// method can be used to mutate outgoing HTTP requests.
+type HTTPAuth interface {
+	Authorizer(*http.Request) error
+}
+
+// Option configures a Client.
+type Option func(*options)
+
+type options struct {
+	ssh  xssh.Options
+	http xhttp.Options
+	git  xgit.Options
+	file file.Options
+
+	schemes map[string]transport.Transport
+}
+
+func (o *options) ensureTLS() *tls.Config {
+	if o.http.TLS == nil {
+		o.http.TLS = &tls.Config{}
+	}
+	return o.http.TLS
+}
+
+// WithSSHAuth sets SSH authentication. The auth type's ClientConfig method
+// is called for each SSH connection.
+func WithSSHAuth(a SSHAuth) Option {
+	return func(o *options) {
+		o.ssh.ClientConfig = a.ClientConfig
+	}
+}
+
+// WithHTTPAuth sets HTTP authentication. The auth type's Authorizer method
+// is called for each outgoing HTTP request.
+func WithHTTPAuth(a HTTPAuth) Option {
+	return func(o *options) {
+		o.http.Authorizer = a.Authorizer
+	}
+}
+
+// WithProxyURL routes all transport connections through the given proxy URL.
+// For HTTP, this uses http.ProxyURL. For SSH and Git TCP, this uses
+// golang.org/x/net/proxy.FromURL to wrap the underlying dialer.
+func WithProxyURL(u *url.URL) Option {
+	return func(o *options) {
+		o.http.HTTPProxy = http.ProxyURL(u)
+
+		wrap := proxyDialer(func(forward proxy.Dialer) (proxy.Dialer, error) {
+			return proxy.FromURL(u, forward)
+		})
+		o.ssh.DialProxy = wrap
+		o.git.DialProxy = wrap
+	}
+}
+
+// WithProxyEnvironment honors standard proxy environment variables
+// (HTTP_PROXY, HTTPS_PROXY, ALL_PROXY, NO_PROXY) for all transports.
+// For HTTP, this uses http.ProxyFromEnvironment. For SSH and Git TCP,
+// this uses golang.org/x/net/proxy.FromEnvironmentUsing.
+func WithProxyEnvironment() Option {
+	return func(o *options) {
+		o.http.HTTPProxy = http.ProxyFromEnvironment
+
+		wrap := proxyDialer(func(forward proxy.Dialer) (proxy.Dialer, error) {
+			return proxy.FromEnvironmentUsing(forward), nil
+		})
+		o.ssh.DialProxy = wrap
+		o.git.DialProxy = wrap
+	}
+}
+
+// WithDialer sets a custom dialer for SSH and Git TCP transports.
+func WithDialer(fn transport.DialContextFunc) Option {
+	return func(o *options) {
+		o.ssh.DialContext = fn
+		o.git.DialContext = fn
+	}
+}
+
+// WithHTTPClient sets the HTTP client used by the HTTP transport.
+// When a custom client is set, WithInsecureSkipTLS, WithCABundle, and
+// WithProxyURL/WithProxyEnvironment do not affect HTTP connections —
+// configure them on the provided client directly.
+func WithHTTPClient(c *http.Client) Option {
+	return func(o *options) {
+		o.http.Client = c
+	}
+}
+
+// WithInsecureSkipTLS disables TLS certificate verification for HTTPS.
+// Can be combined with WithCABundle.
+func WithInsecureSkipTLS() Option {
+	return func(o *options) {
+		o.ensureTLS().InsecureSkipVerify = true
+	}
+}
+
+// WithCABundle sets a PEM-encoded CA certificate bundle for HTTPS
+// connections. When set, only these CAs are trusted.
+// Can be combined with WithInsecureSkipTLS.
+func WithCABundle(pem []byte) Option {
+	return func(o *options) {
+		pool := x509.NewCertPool()
+		pool.AppendCertsFromPEM(pem)
+		o.ensureTLS().RootCAs = pool
+	}
+}
+
+// WithLoader sets the storage loader for the file transport.
+func WithLoader(l transport.Loader) Option {
+	return func(o *options) {
+		o.file.Loader = l
+	}
+}
+
+// WithTransport registers a custom transport for the given URL scheme.
+// This overrides any built-in transport for that scheme.
+func WithTransport(scheme string, tr transport.Transport) Option {
+	return func(o *options) {
+		if o.schemes == nil {
+			o.schemes = make(map[string]transport.Transport)
+		}
+		o.schemes[scheme] = tr
+	}
+}
+
+// Client resolves URL schemes to transport implementations.
+type Client struct {
+	opts options
+}
+
+// New creates a Client with built-in transports for file, git, ssh, http,
+// and https schemes. Options customize authentication, proxying, dialing,
+// and transport overrides.
+func New(opts ...Option) *Client {
+	var o options
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return &Client{opts: o}
+}
+
+// Handshake resolves the transport for the request URL scheme and performs
+// a pack protocol handshake.
+func (c *Client) Handshake(ctx context.Context, req *transport.Request) (transport.Session, error) {
+	tr, err := c.resolve(req)
+	if err != nil {
+		return nil, err
+	}
+	return tr.Handshake(ctx, req)
+}
+
+// Connect resolves the transport for the request URL scheme and opens a
+// raw full-duplex connection. Returns ErrConnectUnsupported if the transport
+// does not implement Connectable (e.g. HTTP).
+func (c *Client) Connect(ctx context.Context, req *transport.Request) (transport.Conn, error) {
+	tr, err := c.resolve(req)
+	if err != nil {
+		return nil, err
+	}
+	conn, ok := tr.(transport.Connectable)
+	if !ok {
+		return nil, transport.ErrConnectUnsupported
+	}
+	return conn.Connect(ctx, req)
+}
+
+// Transport returns the resolved transport for the given URL scheme.
+func (c *Client) Transport(scheme string) (transport.Transport, error) {
+	if c.opts.schemes != nil {
+		if tr, ok := c.opts.schemes[scheme]; ok {
+			return tr, nil
+		}
+	}
+	return c.builtin(scheme)
+}
+
+// Close releases resources held by the client.
+func (c *Client) Close() error {
+	return nil
+}
+
+func (c *Client) resolve(req *transport.Request) (transport.Transport, error) {
+	if req == nil || req.URL == nil {
+		return nil, fmt.Errorf("transport: nil request or URL")
+	}
+	return c.Transport(req.URL.Scheme)
+}
+
+func (c *Client) builtin(scheme string) (transport.Transport, error) {
+	switch scheme {
+	case "file":
+		return file.NewTransport(c.opts.file), nil
+	case "git":
+		return xgit.NewTransport(c.opts.git), nil
+	case "ssh":
+		return xssh.NewTransport(c.opts.ssh), nil
+	case "http", "https":
+		return xhttp.NewTransport(c.opts.http), nil
+	default:
+		return nil, fmt.Errorf("transport: unsupported scheme %q", scheme)
+	}
+}
+
+// proxyDialer creates a DialProxy wrapper from a function that produces
+// a proxy.Dialer given a forwarding proxy.Dialer.
+func proxyDialer(makeDialer func(proxy.Dialer) (proxy.Dialer, error)) func(transport.DialContextFunc) transport.DialContextFunc {
+	return func(direct transport.DialContextFunc) transport.DialContextFunc {
+		d, err := makeDialer(direct)
+		if err != nil {
+			return direct
+		}
+		if cd, ok := d.(proxy.ContextDialer); ok {
+			return cd.DialContext
+		}
+		return func(_ context.Context, network, addr string) (net.Conn, error) {
+			return d.Dial(network, addr)
+		}
+	}
+}

--- a/plumbing/client/client_test.go
+++ b/plumbing/client/client_test.go
@@ -1,0 +1,290 @@
+package client
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	gossh "golang.org/x/crypto/ssh"
+
+	"github.com/go-git/go-git/v6/plumbing/transport"
+	xhttp "github.com/go-git/go-git/v6/plumbing/transport/http"
+	xssh "github.com/go-git/go-git/v6/plumbing/transport/ssh"
+)
+
+func TestNew_BuiltinSchemes(t *testing.T) {
+	t.Parallel()
+
+	c := New()
+	defer c.Close()
+
+	for _, scheme := range []string{"file", "git", "http", "https", "ssh"} {
+		tr, err := c.Transport(scheme)
+		require.NoError(t, err, "scheme %q should be registered", scheme)
+		assert.NotNil(t, tr, "transport for %q should not be nil", scheme)
+	}
+}
+
+func TestNew_ConnectableSchemes(t *testing.T) {
+	t.Parallel()
+
+	c := New()
+	defer c.Close()
+
+	for _, scheme := range []string{"file", "git", "ssh"} {
+		tr, err := c.Transport(scheme)
+		require.NoError(t, err)
+		_, ok := tr.(transport.Connectable)
+		assert.True(t, ok, "scheme %q should implement Connectable", scheme)
+	}
+}
+
+func TestNew_HTTPNotConnectable(t *testing.T) {
+	t.Parallel()
+
+	c := New()
+	defer c.Close()
+
+	for _, scheme := range []string{"http", "https"} {
+		tr, err := c.Transport(scheme)
+		require.NoError(t, err)
+		_, ok := tr.(transport.Connectable)
+		assert.False(t, ok, "scheme %q should NOT implement Connectable", scheme)
+	}
+}
+
+func TestNew_UnsupportedScheme(t *testing.T) {
+	t.Parallel()
+
+	c := New()
+	defer c.Close()
+
+	_, err := c.Transport("ftp")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported scheme")
+}
+
+func TestWithTransport(t *testing.T) {
+	t.Parallel()
+
+	custom := &mockTransport{}
+	c := New(WithTransport("custom", custom))
+	defer c.Close()
+
+	tr, err := c.Transport("custom")
+	require.NoError(t, err)
+	assert.Equal(t, custom, tr)
+}
+
+func TestWithTransport_OverrideBuiltin(t *testing.T) {
+	t.Parallel()
+
+	custom := &mockTransport{}
+	c := New(WithTransport("ssh", custom))
+	defer c.Close()
+
+	tr, err := c.Transport("ssh")
+	require.NoError(t, err)
+	assert.Equal(t, custom, tr)
+}
+
+func TestWithSSHAuth(t *testing.T) {
+	t.Parallel()
+
+	auth := &xssh.Password{
+		User:     "git",
+		Password: "secret",
+		HostKeyCallbackHelper: xssh.HostKeyCallbackHelper{
+			HostKeyCallback: gossh.InsecureIgnoreHostKey(),
+		},
+	}
+
+	c := New(WithSSHAuth(auth))
+	defer c.Close()
+
+	tr, err := c.Transport("ssh")
+	require.NoError(t, err)
+	assert.NotNil(t, tr)
+}
+
+func TestWithHTTPAuth(t *testing.T) {
+	t.Parallel()
+
+	auth := &xhttp.BasicAuth{Username: "user", Password: "pass"}
+
+	c := New(WithHTTPAuth(auth))
+	defer c.Close()
+
+	tr, err := c.Transport("http")
+	require.NoError(t, err)
+	assert.NotNil(t, tr)
+}
+
+func TestWithHTTPClient(t *testing.T) {
+	t.Parallel()
+
+	custom := &http.Client{}
+	c := New(WithHTTPClient(custom))
+	defer c.Close()
+
+	tr, err := c.Transport("https")
+	require.NoError(t, err)
+	assert.NotNil(t, tr)
+}
+
+func TestWithProxyURL(t *testing.T) {
+	t.Parallel()
+
+	proxyURL, err := url.Parse("socks5://proxy.example:1080")
+	require.NoError(t, err)
+
+	c := New(WithProxyURL(proxyURL))
+	defer c.Close()
+
+	for _, scheme := range []string{"ssh", "git", "http", "https"} {
+		tr, err := c.Transport(scheme)
+		require.NoError(t, err, "scheme %q", scheme)
+		assert.NotNil(t, tr, "scheme %q", scheme)
+	}
+}
+
+func TestWithProxyEnvironment(t *testing.T) {
+	t.Parallel()
+
+	c := New(WithProxyEnvironment())
+	defer c.Close()
+
+	for _, scheme := range []string{"ssh", "git", "http", "https"} {
+		tr, err := c.Transport(scheme)
+		require.NoError(t, err, "scheme %q", scheme)
+		assert.NotNil(t, tr, "scheme %q", scheme)
+	}
+}
+
+func TestWithDialer(t *testing.T) {
+	t.Parallel()
+
+	c := New(WithDialer((&net.Dialer{}).DialContext))
+	defer c.Close()
+
+	for _, scheme := range []string{"ssh", "git"} {
+		tr, err := c.Transport(scheme)
+		require.NoError(t, err, "scheme %q", scheme)
+		assert.NotNil(t, tr, "scheme %q", scheme)
+	}
+}
+
+func TestWithLoader(t *testing.T) {
+	t.Parallel()
+
+	loader := transport.MapLoader{}
+	c := New(WithLoader(loader))
+	defer c.Close()
+
+	tr, err := c.Transport("file")
+	require.NoError(t, err)
+	assert.NotNil(t, tr)
+}
+
+func TestMultipleOptions(t *testing.T) {
+	t.Parallel()
+
+	auth := &xhttp.BasicAuth{Username: "u", Password: "p"}
+	custom := &mockTransport{}
+
+	c := New(
+		WithHTTPAuth(auth),
+		WithTransport("custom", custom),
+	)
+	defer c.Close()
+
+	tr, err := c.Transport("custom")
+	require.NoError(t, err)
+	assert.Equal(t, custom, tr)
+
+	tr, err = c.Transport("http")
+	require.NoError(t, err)
+	assert.NotNil(t, tr)
+}
+
+func TestNilRequest(t *testing.T) {
+	t.Parallel()
+
+	c := New()
+	defer c.Close()
+
+	_, err := c.Handshake(context.Background(), nil)
+	require.Error(t, err)
+
+	_, err = c.Connect(context.Background(), nil)
+	require.Error(t, err)
+}
+
+func TestWithInsecureSkipTLS(t *testing.T) {
+	t.Parallel()
+
+	c := New(WithInsecureSkipTLS())
+	defer c.Close()
+
+	tr, err := c.Transport("https")
+	require.NoError(t, err)
+	assert.NotNil(t, tr)
+}
+
+func TestWithCABundle(t *testing.T) {
+	t.Parallel()
+
+	c := New(WithCABundle(testCAPEM))
+	defer c.Close()
+
+	tr, err := c.Transport("https")
+	require.NoError(t, err)
+	assert.NotNil(t, tr)
+}
+
+func TestWithInsecureSkipTLS_And_WithCABundle_Merge(t *testing.T) {
+	t.Parallel()
+
+	var o options
+	WithInsecureSkipTLS()(&o)
+	WithCABundle(testCAPEM)(&o)
+
+	require.NotNil(t, o.http.TLS)
+	assert.True(t, o.http.TLS.InsecureSkipVerify)
+	assert.NotNil(t, o.http.TLS.RootCAs)
+}
+
+func TestWithInsecureSkipTLS_And_WithCABundle_ReverseOrder(t *testing.T) {
+	t.Parallel()
+
+	var o options
+	WithCABundle(testCAPEM)(&o)
+	WithInsecureSkipTLS()(&o)
+
+	require.NotNil(t, o.http.TLS)
+	assert.True(t, o.http.TLS.InsecureSkipVerify)
+	assert.NotNil(t, o.http.TLS.RootCAs)
+}
+
+// Self-signed CA certificate for testing.
+var testCAPEM = []byte(`-----BEGIN CERTIFICATE-----
+MIIBkTCB+wIJALRiMLAh4HMHMA0GCSqGSIb3DQEBCwUAMBExDzANBgNVBAMMBnRl
+c3RjYTAeFw0yNDA0MDQwMDAwMDBaFw0zNDA0MDIwMDAwMDBaMBExDzANBgNVBAMM
+BnRlc3RjYTBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQC7o96+IG5sKBe0QKbsBigc
+GsR8cKQuDfhCFqzWn7zr4aqHsLQiKEJsClMDGnNHEFGDFpXuIFxnGOTPYFOYIuDH
+AgMBAAGjUzBRMB0GA1UdDgQWBBQgTxe0MCRKYB0ILQM0L7V/lMjxNjAfBgNVHSME
+GDAWgBQgTxe0MCRKYB0ILQM0L7V/lMjxNjAPBgNVHRMBAf8EBTADAQH/MA0GCSqG
+SIb3DQEBCwUAA0EAh/8fnFa6VW1cB8QJWIM4KpCmpY9R1YMaqGCbDjM0FZmE+dqA
+NsaKMCSE1YOIMBN6mBUX3iTmy/sCTIYMBbFPgQ==
+-----END CERTIFICATE-----
+`)
+
+type mockTransport struct{}
+
+func (m *mockTransport) Handshake(_ context.Context, _ *transport.Request) (transport.Session, error) {
+	return nil, nil
+}


### PR DESCRIPTION
Add plumbing/client from x/client. This package provides scheme-based transport resolution, replacing the old registry.go functionality.