### PR TITLE
plumbing: format/pktline, converge sideband mux/demux into pktline

### DIFF
--- a/plumbing/format/pktline/common.go
+++ b/plumbing/format/pktline/common.go
@@ -27,12 +27,33 @@ const (
 	// See https://git-scm.com/docs/protocol-common#_pkt_line_format
 	MaxPayloadSize = MaxSize - LenSize
 
-	// MaxSize is the maximum packet size of a pkt-line in bytes.
+	// MaxSize is the maximum packet size of a pkt-line in bytes
+	// (LARGE_PACKET_MAX in canonical Git).
 	// See https://git-scm.com/docs/protocol-common#_pkt_line_format
 	MaxSize = 65520
 
+	// DefaultSize is the maximum pkt-line size for legacy side-band
+	// (DEFAULT_PACKET_MAX in canonical Git). Includes the 4-byte length
+	// header.
+	DefaultSize = 1000
+
+	// DefaultPayloadSize is the maximum payload size for legacy side-band
+	// (DefaultSize minus the 4-byte length header).
+	DefaultPayloadSize = DefaultSize - LenSize
+
 	// LenSize is the size of the packet length in bytes.
 	LenSize = 4
+)
+
+// Sideband channel identifiers. These are the first byte of the pkt-line
+// payload in sideband-framed streams.
+const (
+	// BandData carries primary pack data.
+	BandData byte = 1
+	// BandProgress carries informational progress messages.
+	BandProgress byte = 2
+	// BandError carries a fatal error message; the stream aborts after this.
+	BandError byte = 3
 )
 
 var (

--- a/plumbing/format/pktline/pktline_fuzz_test.go
+++ b/plumbing/format/pktline/pktline_fuzz_test.go
@@ -73,6 +73,30 @@ func FuzzReadLine(f *testing.F) {
 	})
 }
 
+func FuzzSidebandReader(f *testing.F) {
+	f.Add([]byte{})
+	f.Add([]byte("0000"))
+	f.Add([]byte("0005\x01"))
+	f.Add([]byte("000a\x01hello"))
+	f.Add([]byte("000a\x02prog\n"))
+	f.Add([]byte("000a\x03oops"))
+	f.Add([]byte("0007\x02hi"))
+	f.Add(append([]byte("0008\x01ab"), []byte("0000")...))
+
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		for _, max := range []int{DefaultSize, MaxSize} {
+			r := NewSidebandReader(bytes.NewReader(data), nil, max)
+			buf := make([]byte, 64)
+			for range 100 {
+				_, err := r.Read(buf)
+				if err != nil {
+					break
+				}
+			}
+		}
+	})
+}
+
 func FuzzSidebandScanner(f *testing.F) {
 	f.Add([]byte{})
 	f.Add([]byte("0000"))

--- a/plumbing/format/pktline/pktline_fuzz_test.go
+++ b/plumbing/format/pktline/pktline_fuzz_test.go
@@ -73,6 +73,32 @@ func FuzzReadLine(f *testing.F) {
 	})
 }
 
+func FuzzSidebandScanner(f *testing.F) {
+	f.Add([]byte{})
+	f.Add([]byte("0000"))
+	f.Add([]byte("0005\x01"))
+	f.Add([]byte("000a\x01hello"))
+	f.Add([]byte("000a\x02prog\n"))
+	f.Add([]byte("000a\x03oops"))
+	f.Add([]byte("0007\x02hi"))
+	f.Add([]byte("0007\x07hi"))
+	f.Add([]byte("0008\x02ab\r"))
+	f.Add(append([]byte("0008\x01ab"), []byte("0000")...))
+
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		for _, max := range []int{DefaultSize, MaxSize} {
+			sc := NewSidebandScanner(bytes.NewReader(data), nil, max)
+			for range 100 {
+				if !sc.Scan() {
+					break
+				}
+				_, _, _ = sc.Len(), sc.Bytes(), sc.Text()
+			}
+			_ = sc.Err()
+		}
+	})
+}
+
 func FuzzScanner(f *testing.F) {
 	f.Add([]byte{})
 	f.Add([]byte("0000"))

--- a/plumbing/format/pktline/pktline_fuzz_test.go
+++ b/plumbing/format/pktline/pktline_fuzz_test.go
@@ -3,6 +3,7 @@ package pktline
 import (
 	"bufio"
 	"bytes"
+	"io"
 	"testing"
 )
 
@@ -68,6 +69,34 @@ func FuzzReadLine(f *testing.F) {
 			_, _, err := ReadLine(r)
 			if err != nil || r.Len() == 0 || r.Len() == before {
 				break
+			}
+		}
+	})
+}
+
+func FuzzSidebandRoundTrip(f *testing.F) {
+	f.Add([]byte{}, uint8(1))
+	f.Add([]byte("hello"), uint8(1))
+	f.Add([]byte("progress\n"), uint8(2))
+	f.Add(bytes.Repeat([]byte("a"), MaxPayloadSize+10), uint8(1))
+	f.Add(bytes.Repeat([]byte("b"), DefaultSize*2), uint8(1))
+
+	f.Fuzz(func(t *testing.T, payload []byte, b uint8) {
+		band := byte(b%3) + 1
+		for _, max := range []int{DefaultSize, MaxSize} {
+			var buf bytes.Buffer
+			if _, err := WriteSideband(&buf, band, payload, max); err != nil {
+				continue
+			}
+			s := NewSidebandScanner(&buf, io.Discard, max)
+			var got []byte
+			for s.Scan() {
+				got = append(got, s.Bytes()...)
+			}
+			if band == BandData {
+				if !bytes.Equal(got, payload) {
+					t.Fatalf("round-trip mismatch: got %d bytes, want %d (max=%d)", len(got), len(payload), max)
+				}
 			}
 		}
 	})

--- a/plumbing/format/pktline/reader.go
+++ b/plumbing/format/pktline/reader.go
@@ -1,0 +1,79 @@
+package pktline
+
+import (
+	"bytes"
+	"io"
+)
+
+// Reader provides io.Reader semantics over a pkt-line stream.
+//
+// When constructed with [NewSidebandReader], Reader transparently
+// demultiplexes sideband: [BandData] payloads are returned via Read,
+// [BandProgress] is consumed by the underlying [Scanner] and forwarded
+// to the progress writer, and [BandError] causes Read to return a
+// [*SidebandError].
+//
+// When constructed with [NewReader], Reader returns plain pkt-line
+// payloads concatenated as a byte stream.
+//
+// In both modes, flush-pkt, delim-pkt, and response-end-pkt terminate
+// the stream (Read returns io.EOF). Callers that need to distinguish
+// these markers should use [Scanner] directly, where Len reports the
+// special length (Flush=0, Delim=1, ResponseEnd=2).
+type Reader struct {
+	s       *Scanner
+	pending []byte // remainder of current packet not yet returned
+}
+
+// NewReader returns a Reader that reads plain pkt-line payloads as a
+// byte stream. Flush, delim, or response-end terminate the stream.
+func NewReader(r io.Reader) *Reader {
+	return &Reader{s: NewScanner(r)}
+}
+
+// NewSidebandReader returns a Reader that demultiplexes sideband
+// packets. [BandData] is returned via Read; [BandProgress] is
+// line-buffered, prefixed with "remote: ", and written to progress
+// (nil progress is treated as io.Discard); [BandError] causes Read to
+// return a [*SidebandError]. The max parameter is the maximum on-wire
+// pkt-line size: use [DefaultSize] for legacy side-band or [MaxSize]
+// for sideband-64k.
+func NewSidebandReader(r io.Reader, progress io.Writer, max int) *Reader {
+	return &Reader{s: NewSidebandScanner(r, progress, max)}
+}
+
+// Read implements io.Reader.
+func (r *Reader) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if len(r.pending) > 0 {
+		n := copy(p, r.pending)
+		r.pending = r.pending[n:]
+		if len(r.pending) == 0 {
+			r.pending = nil
+		}
+		return n, nil
+	}
+	for {
+		if !r.s.Scan() {
+			if err := r.s.Err(); err != nil {
+				return 0, err
+			}
+			return 0, io.EOF
+		}
+		switch r.s.Len() {
+		case Flush, Delim, ResponseEnd:
+			return 0, io.EOF
+		}
+		payload := r.s.Bytes()
+		if len(payload) == 0 {
+			continue
+		}
+		n := copy(p, payload)
+		if n < len(payload) {
+			r.pending = bytes.Clone(payload[n:])
+		}
+		return n, nil
+	}
+}

--- a/plumbing/format/pktline/reader_test.go
+++ b/plumbing/format/pktline/reader_test.go
@@ -1,0 +1,178 @@
+package pktline_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
+)
+
+func TestReader_Plain_Concatenates(t *testing.T) {
+	var buf bytes.Buffer
+	for _, s := range []string{"foo", "bar", "baz"} {
+		if _, err := pktline.WriteString(&buf, s); err != nil {
+			t.Fatal(err)
+		}
+	}
+	r := pktline.NewReader(&buf)
+	got, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if string(got) != "foobarbaz" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestReader_Plain_EOFOnFlush(t *testing.T) {
+	var buf bytes.Buffer
+	if _, err := pktline.WriteString(&buf, "first"); err != nil {
+		t.Fatal(err)
+	}
+	if err := pktline.WriteFlush(&buf); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pktline.WriteString(&buf, "after-flush"); err != nil {
+		t.Fatal(err)
+	}
+	r := pktline.NewReader(&buf)
+	got, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if string(got) != "first" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestReader_Plain_EOFOnDelim(t *testing.T) {
+	var buf bytes.Buffer
+	if _, err := pktline.WriteString(&buf, "x"); err != nil {
+		t.Fatal(err)
+	}
+	if err := pktline.WriteDelim(&buf); err != nil {
+		t.Fatal(err)
+	}
+	r := pktline.NewReader(&buf)
+	got, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if string(got) != "x" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestReader_ZeroLength(t *testing.T) {
+	r := pktline.NewReader(bytes.NewReader(nil))
+	n, err := r.Read(nil)
+	if n != 0 || err != nil {
+		t.Fatalf("Read(nil) = (%d, %v)", n, err)
+	}
+}
+
+func TestReader_PartialBufferSpansReads(t *testing.T) {
+	var src bytes.Buffer
+	if _, err := pktline.WriteString(&src, "abcdefghij"); err != nil {
+		t.Fatal(err)
+	}
+	r := pktline.NewReader(&src)
+	got, err := io.ReadAll(readByOneByte{r})
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if string(got) != "abcdefghij" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestReader_SkipsEmptyPackets(t *testing.T) {
+	var src bytes.Buffer
+	if _, err := pktline.Write(&src, nil); err != nil { // empty data packet (0004)
+		t.Fatal(err)
+	}
+	if _, err := pktline.WriteString(&src, "after-empty"); err != nil {
+		t.Fatal(err)
+	}
+	r := pktline.NewReader(&src)
+	got, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if string(got) != "after-empty" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestSidebandReader_Concatenates(t *testing.T) {
+	var src bytes.Buffer
+	src.Write(sbPkt(t, pktline.BandData, []byte("PACK")))
+	src.Write(sbPkt(t, pktline.BandProgress, []byte("counting\n")))
+	src.Write(sbPkt(t, pktline.BandData, []byte("data")))
+	if err := pktline.WriteFlush(&src); err != nil {
+		t.Fatal(err)
+	}
+
+	var progress bytes.Buffer
+	r := pktline.NewSidebandReader(&src, &progress, pktline.MaxSize)
+	got, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if string(got) != "PACKdata" {
+		t.Fatalf("data = %q", got)
+	}
+	if progress.String() != "remote: counting\n" {
+		t.Fatalf("progress = %q", progress.String())
+	}
+}
+
+func TestSidebandReader_BandErrorSurfaces(t *testing.T) {
+	var src bytes.Buffer
+	src.Write(sbPkt(t, pktline.BandData, []byte("partial")))
+	src.Write(sbPkt(t, pktline.BandError, []byte("boom")))
+
+	r := pktline.NewSidebandReader(&src, nil, pktline.MaxSize)
+	got, err := io.ReadAll(r)
+	if string(got) != "partial" {
+		t.Fatalf("data = %q", got)
+	}
+	var se *pktline.SidebandError
+	if !errors.As(err, &se) {
+		t.Fatalf("err = %v, want *SidebandError", err)
+	}
+	if se.Msg != "boom" {
+		t.Fatalf("Msg = %q", se.Msg)
+	}
+}
+
+func TestSidebandReader_NilProgress(t *testing.T) {
+	var src bytes.Buffer
+	src.Write(sbPkt(t, pktline.BandProgress, []byte("ignored\n")))
+	src.Write(sbPkt(t, pktline.BandData, []byte("ok")))
+
+	r := pktline.NewSidebandReader(&src, nil, pktline.MaxSize)
+	got, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if string(got) != "ok" {
+		t.Fatalf("data = %q", got)
+	}
+}
+
+type readByOneByte struct{ r io.Reader }
+
+func (r readByOneByte) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	var b [1]byte
+	n, err := r.r.Read(b[:])
+	if n > 0 {
+		p[0] = b[0]
+	}
+	return n, err
+}

--- a/plumbing/format/pktline/scanner.go
+++ b/plumbing/format/pktline/scanner.go
@@ -1,7 +1,9 @@
 package pktline
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
 	"io"
 )
 
@@ -20,18 +22,57 @@ import (
 // from Bytes; Len returns the pkt-line length, which equals the
 // corresponding constant (Flush=0, Delim=1, ResponseEnd=2).
 //
+// When constructed with [NewSidebandScanner], the Scanner demultiplexes
+// sideband packets: [BandData] payloads are returned via Bytes (with the
+// band byte stripped); [BandProgress] payloads are line-buffered, prefixed
+// with "remote: ", and written to the configured progress writer;
+// [BandError] terminates scanning and is surfaced via Err as a
+// [*SidebandError].
+//
 // Scanning stops at EOF or the first I/O error.
 type Scanner struct {
 	r   io.Reader     // The reader provided by the client
 	err error         // Sticky error
 	buf [MaxSize]byte // Buffer used to read the pktlines
 	n   int           // Number of bytes read in the last read
+
+	sideband bool      // when true, Scan demultiplexes sideband
+	max      int       // max on-wire pkt-line size (DefaultSize or MaxSize)
+	progress io.Writer // destination for band-2 (progress) data
+	scratch  []byte    // buffers partial band-2 progress lines
 }
+
+// remotePrefix is prepended to each progress line written by a sideband
+// Scanner, matching the prefix canonical Git applies in recv_sideband.
+var remotePrefix = []byte("remote: ")
 
 // NewScanner returns a new Scanner to read from r.
 func NewScanner(r io.Reader) *Scanner {
 	return &Scanner{
 		r: r,
+	}
+}
+
+// NewSidebandScanner returns a Scanner that demultiplexes sideband
+// packets. The max parameter is the maximum on-wire pkt-line size for the
+// negotiated sideband variant: use [DefaultSize] for legacy side-band or
+// [MaxSize] for sideband-64k. If progress is nil, band-2 progress data is
+// discarded.
+//
+// Band-1 data is returned via Bytes (with the band byte stripped); band-2
+// progress is line-buffered, prefixed with "remote: ", and written to
+// progress on \n or \r boundaries (any residual partial line is flushed
+// when the stream terminates); band-3 errors are returned from Err as
+// [*SidebandError].
+func NewSidebandScanner(r io.Reader, progress io.Writer, max int) *Scanner {
+	if progress == nil {
+		progress = io.Discard
+	}
+	return &Scanner{
+		r:        r,
+		sideband: true,
+		max:      max,
+		progress: progress,
 	}
 }
 
@@ -45,16 +86,108 @@ func (s *Scanner) Err() error {
 // or the first I/O error.  After Scan returns false, the Err method
 // will return any error that occurred during scanning, except that if
 // it was io.EOF, Err will return nil.
+//
+// In sideband mode, band-2 (progress) packets are consumed transparently
+// and Scan loops to the next packet; band-3 (error) packets terminate
+// scanning with a [*SidebandError] surfaced via Err.
 func (s *Scanner) Scan() bool {
 	if s.r == nil {
 		return false
 	}
-	s.n, s.err = Read(s.r, s.buf[:])
-	if errors.Is(s.err, io.EOF) {
-		s.err = nil
-		return false
+	if !s.sideband {
+		s.n, s.err = Read(s.r, s.buf[:])
+		if errors.Is(s.err, io.EOF) {
+			s.err = nil
+			return false
+		}
+		return s.err == nil
 	}
-	return s.err == nil
+	return s.scanSideband()
+}
+
+// scanSideband reads the next sideband pkt-line, routing band-2 progress
+// data to s.progress and surfacing band-3 errors via s.err. It loops over
+// band-2 packets until a band-1, special, or terminal event is observed.
+func (s *Scanner) scanSideband() bool {
+	for {
+		s.n, s.err = Read(s.r, s.buf[:])
+		if errors.Is(s.err, io.EOF) {
+			s.err = nil
+			s.flushScratch()
+			return false
+		}
+		if s.err != nil {
+			s.flushScratch()
+			return false
+		}
+
+		if s.n > s.max {
+			s.err = ErrMaxPacketExceeded
+			s.flushScratch()
+			return false
+		}
+
+		switch s.n {
+		case Flush, Delim, ResponseEnd:
+			s.flushScratch()
+			return true
+		}
+
+		if s.n < LenSize+1 {
+			s.flushScratch()
+			s.err = errors.New("pktline: sideband packet missing band byte")
+			return false
+		}
+
+		band := s.buf[LenSize]
+		switch band {
+		case BandData:
+			return true
+		case BandProgress:
+			s.writeProgress(s.buf[LenSize+1 : s.n])
+			continue
+		case BandError:
+			s.flushScratch()
+			s.err = &SidebandError{Msg: string(s.buf[LenSize+1 : s.n])}
+			return false
+		default:
+			s.flushScratch()
+			s.err = fmt.Errorf("pktline: unknown sideband channel %d", band)
+			return false
+		}
+	}
+}
+
+// writeProgress buffers band-2 data in s.scratch and writes complete lines
+// (terminated by \n or \r) to s.progress, each prefixed with "remote: ".
+func (s *Scanner) writeProgress(p []byte) {
+	if len(p) == 0 {
+		return
+	}
+	s.scratch = append(s.scratch, p...)
+	for {
+		i := bytes.IndexAny(s.scratch, "\r\n")
+		if i < 0 {
+			return
+		}
+		out := make([]byte, 0, len(remotePrefix)+i+1)
+		out = append(out, remotePrefix...)
+		out = append(out, s.scratch[:i+1]...)
+		_, _ = s.progress.Write(out)
+		s.scratch = s.scratch[i+1:]
+	}
+}
+
+// flushScratch emits any pending progress data as a final "remote: " line.
+func (s *Scanner) flushScratch() {
+	if len(s.scratch) == 0 {
+		return
+	}
+	out := make([]byte, 0, len(remotePrefix)+len(s.scratch))
+	out = append(out, remotePrefix...)
+	out = append(out, s.scratch...)
+	_, _ = s.progress.Write(out)
+	s.scratch = s.scratch[:0]
 }
 
 // Bytes returns the payload of the most recent pkt-line as a slice
@@ -64,11 +197,17 @@ func (s *Scanner) Scan() bool {
 //
 // Bytes does no allocation. It returns nil for special pkt-lines
 // ([Flush], [Delim], [ResponseEnd]); use [Len] to distinguish them.
+//
+// In sideband mode, Bytes returns the band-1 payload with the leading
+// band byte stripped.
 func (s *Scanner) Bytes() []byte {
-	if s.n >= LenSize {
-		return s.buf[LenSize:s.n]
+	if s.n < LenSize {
+		return nil
 	}
-	return nil
+	if s.sideband {
+		return s.buf[LenSize+1 : s.n]
+	}
+	return s.buf[LenSize:s.n]
 }
 
 // Text returns the most recent packet generated by a call to Scan.
@@ -78,8 +217,9 @@ func (s *Scanner) Text() string {
 
 // Len returns the pkt-line length of the most recent pkt-line. For data
 // lines this is the length of the entire pkt-line including the 4-byte
-// length prefix. For special pkt-lines, Len returns the corresponding
-// constant: [Flush] (0), [Delim] (1), or [ResponseEnd] (2).
+// length prefix (and, in sideband mode, the 1-byte band prefix). For
+// special pkt-lines, Len returns the corresponding constant: [Flush] (0),
+// [Delim] (1), or [ResponseEnd] (2).
 func (s *Scanner) Len() int {
 	return s.n
 }

--- a/plumbing/format/pktline/scanner_sideband_test.go
+++ b/plumbing/format/pktline/scanner_sideband_test.go
@@ -1,0 +1,252 @@
+package pktline_test
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
+)
+
+// pkt builds a data pkt-line with the given payload. Payload must fit in
+// MaxPayloadSize bytes.
+func pkt(t *testing.T, payload []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	if _, err := pktline.Write(&buf, payload); err != nil {
+		t.Fatalf("pkt: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// sbPkt builds a sideband data pkt-line on the given band.
+func sbPkt(t *testing.T, band byte, payload []byte) []byte {
+	t.Helper()
+	return pkt(t, append([]byte{band}, payload...))
+}
+
+func TestSidebandScanner_BandData(t *testing.T) {
+	var src bytes.Buffer
+	src.Write(sbPkt(t, pktline.BandData, []byte("hello ")))
+	src.Write(sbPkt(t, pktline.BandData, []byte("world")))
+
+	var progress bytes.Buffer
+	s := pktline.NewSidebandScanner(&src, &progress, pktline.MaxSize)
+
+	var got []byte
+	for s.Scan() {
+		got = append(got, s.Bytes()...)
+	}
+	if err := s.Err(); err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	if string(got) != "hello world" {
+		t.Fatalf("data = %q", got)
+	}
+	if progress.Len() != 0 {
+		t.Fatalf("unexpected progress: %q", progress.String())
+	}
+}
+
+func TestSidebandScanner_ProgressLineBuffering(t *testing.T) {
+	var src bytes.Buffer
+	// "Counting" split across two band-2 packets; full line only completes
+	// at the trailing '\n' in the second packet.
+	src.Write(sbPkt(t, pktline.BandProgress, []byte("Counti")))
+	src.Write(sbPkt(t, pktline.BandProgress, []byte("ng objects\n")))
+	// Two CR-delimited progress fragments in a single band-2 packet.
+	src.Write(sbPkt(t, pktline.BandProgress, []byte("Resolving deltas: 50%\rResolving deltas: 100%\r")))
+	src.Write(sbPkt(t, pktline.BandData, []byte("pack")))
+
+	var progress bytes.Buffer
+	s := pktline.NewSidebandScanner(&src, &progress, pktline.MaxSize)
+
+	var data []byte
+	for s.Scan() {
+		data = append(data, s.Bytes()...)
+	}
+	if err := s.Err(); err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	if string(data) != "pack" {
+		t.Fatalf("data = %q", data)
+	}
+	want := "remote: Counting objects\nremote: Resolving deltas: 50%\rremote: Resolving deltas: 100%\r"
+	if progress.String() != want {
+		t.Fatalf("progress = %q\nwant      %q", progress.String(), want)
+	}
+}
+
+func TestSidebandScanner_ResidualProgressFlushedOnEOF(t *testing.T) {
+	var src bytes.Buffer
+	src.Write(sbPkt(t, pktline.BandProgress, []byte("trailing")))
+	// stream ends without a newline.
+
+	var progress bytes.Buffer
+	s := pktline.NewSidebandScanner(&src, &progress, pktline.MaxSize)
+	for s.Scan() {
+	}
+	if err := s.Err(); err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	if progress.String() != "remote: trailing" {
+		t.Fatalf("progress = %q", progress.String())
+	}
+}
+
+func TestSidebandScanner_BandError(t *testing.T) {
+	var src bytes.Buffer
+	src.Write(sbPkt(t, pktline.BandData, []byte("partial")))
+	src.Write(sbPkt(t, pktline.BandError, []byte("server exploded")))
+	src.Write(sbPkt(t, pktline.BandData, []byte("never seen")))
+
+	s := pktline.NewSidebandScanner(&src, nil, pktline.MaxSize)
+	var data []byte
+	for s.Scan() {
+		data = append(data, s.Bytes()...)
+	}
+	if string(data) != "partial" {
+		t.Fatalf("data = %q", data)
+	}
+	var se *pktline.SidebandError
+	if !errors.As(s.Err(), &se) {
+		t.Fatalf("Err = %v, want *SidebandError", s.Err())
+	}
+	if se.Msg != "server exploded" {
+		t.Fatalf("Msg = %q", se.Msg)
+	}
+}
+
+func TestSidebandScanner_ResidualProgressFlushedOnBand3(t *testing.T) {
+	var src bytes.Buffer
+	src.Write(sbPkt(t, pktline.BandProgress, []byte("midline")))
+	src.Write(sbPkt(t, pktline.BandError, []byte("boom")))
+
+	var progress bytes.Buffer
+	s := pktline.NewSidebandScanner(&src, &progress, pktline.MaxSize)
+	for s.Scan() {
+	}
+	var se *pktline.SidebandError
+	if !errors.As(s.Err(), &se) {
+		t.Fatalf("Err = %v", s.Err())
+	}
+	if progress.String() != "remote: midline" {
+		t.Fatalf("progress = %q", progress.String())
+	}
+}
+
+func TestSidebandScanner_MaxPacketExceeded(t *testing.T) {
+	// One byte over DefaultSize on the wire.
+	payload := bytes.Repeat([]byte("a"), pktline.DefaultPayloadSize) // 996 bytes; +4 header + 1 band byte = 1001
+	src := sbPkt(t, pktline.BandData, payload)
+
+	s := pktline.NewSidebandScanner(bytes.NewReader(src), nil, pktline.DefaultSize)
+	if s.Scan() {
+		t.Fatalf("Scan succeeded; want failure")
+	}
+	if !errors.Is(s.Err(), pktline.ErrMaxPacketExceeded) {
+		t.Fatalf("Err = %v, want ErrMaxPacketExceeded", s.Err())
+	}
+}
+
+func TestSidebandScanner_MaxPacketAllowedAtBoundary(t *testing.T) {
+	// Exactly at DefaultSize: 4-byte header + 1-byte band + 995-byte payload = 1000.
+	payload := bytes.Repeat([]byte("a"), pktline.DefaultPayloadSize-1)
+	src := sbPkt(t, pktline.BandData, payload)
+
+	s := pktline.NewSidebandScanner(bytes.NewReader(src), nil, pktline.DefaultSize)
+	if !s.Scan() {
+		t.Fatalf("Scan failed: %v", s.Err())
+	}
+	if !bytes.Equal(s.Bytes(), payload) {
+		t.Fatalf("payload mismatch")
+	}
+}
+
+func TestSidebandScanner_FlushDelimResponseEnd(t *testing.T) {
+	var src bytes.Buffer
+	src.Write(sbPkt(t, pktline.BandData, []byte("x")))
+	if err := pktline.WriteDelim(&src); err != nil {
+		t.Fatal(err)
+	}
+	src.Write(sbPkt(t, pktline.BandData, []byte("y")))
+	if err := pktline.WriteFlush(&src); err != nil {
+		t.Fatal(err)
+	}
+
+	s := pktline.NewSidebandScanner(&src, nil, pktline.MaxSize)
+	var lens []int
+	var got []byte
+	for s.Scan() {
+		lens = append(lens, s.Len())
+		got = append(got, s.Bytes()...)
+	}
+	if err := s.Err(); err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	if string(got) != "xy" {
+		t.Fatalf("data = %q", got)
+	}
+	wantLens := []int{LenForData(t, 1), pktline.Delim, LenForData(t, 1), pktline.Flush}
+	if !equalInts(lens, wantLens) {
+		t.Fatalf("lens = %v, want %v", lens, wantLens)
+	}
+}
+
+func TestSidebandScanner_UnknownBand(t *testing.T) {
+	src := sbPkt(t, 7, []byte("nope"))
+	s := pktline.NewSidebandScanner(bytes.NewReader(src), nil, pktline.MaxSize)
+	if s.Scan() {
+		t.Fatalf("Scan succeeded; want failure")
+	}
+	if s.Err() == nil || !strings.Contains(s.Err().Error(), "unknown sideband channel") {
+		t.Fatalf("Err = %v", s.Err())
+	}
+}
+
+func TestSidebandScanner_NilProgress(t *testing.T) {
+	var src bytes.Buffer
+	src.Write(sbPkt(t, pktline.BandProgress, []byte("ignored\n")))
+	src.Write(sbPkt(t, pktline.BandData, []byte("d")))
+
+	s := pktline.NewSidebandScanner(&src, nil, pktline.MaxSize)
+	for s.Scan() {
+	}
+	if err := s.Err(); err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+}
+
+func TestSidebandScanner_PlainScannerUnchanged(t *testing.T) {
+	var buf bytes.Buffer
+	if _, err := pktline.Write(&buf, []byte("plain")); err != nil {
+		t.Fatal(err)
+	}
+	s := pktline.NewScanner(&buf)
+	if !s.Scan() {
+		t.Fatalf("Scan failed: %v", s.Err())
+	}
+	if string(s.Bytes()) != "plain" {
+		t.Fatalf("payload = %q", s.Bytes())
+	}
+}
+
+// LenForData returns the on-wire length of a sideband data pkt-line with
+// the given non-band payload length.
+func LenForData(t *testing.T, payloadLen int) int {
+	t.Helper()
+	return pktline.LenSize + 1 + payloadLen
+}
+
+func equalInts(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/plumbing/format/pktline/sideband.go
+++ b/plumbing/format/pktline/sideband.go
@@ -1,0 +1,17 @@
+package pktline
+
+import "errors"
+
+// ErrMaxPacketExceeded is returned when a pkt-line exceeds the maximum size
+// allowed for the negotiated sideband variant.
+var ErrMaxPacketExceeded = errors.New("pktline: max packet size exceeded")
+
+// SidebandError is returned when a band-3 (fatal error) packet is received
+// on a sideband stream. The stream is expected to terminate after this
+// packet.
+type SidebandError struct {
+	Msg string
+}
+
+// Error implements the error interface.
+func (e *SidebandError) Error() string { return e.Msg }

--- a/plumbing/format/pktline/writer.go
+++ b/plumbing/format/pktline/writer.go
@@ -1,0 +1,139 @@
+package pktline
+
+import (
+	"errors"
+	"io"
+)
+
+// Writer writes pkt-lines to an underlying io.Writer.
+//
+// In plain mode (constructed with [NewWriter]), Write emits raw
+// pkt-lines: payloads larger than the chunk limit are split across
+// multiple pkt-lines.
+//
+// In sideband mode (constructed with [NewSidebandWriter]), Write emits
+// [BandData] pkt-lines, WriteProgress emits [BandProgress] pkt-lines,
+// and each on-wire pkt-line is bounded by the max parameter. The only
+// difference between plain and sideband Write is the band byte prefix.
+//
+// Callers that need exactly one pkt-line per Write call should use the
+// top-level [Write] function, which errors on payloads exceeding
+// [MaxPayloadSize].
+type Writer struct {
+	w        io.Writer
+	sideband bool
+	max      int // max on-wire pkt-line size (DefaultSize or MaxSize)
+}
+
+// NewWriter returns a Writer that emits plain pkt-lines. Payloads
+// larger than [MaxPayloadSize] are split across multiple pkt-lines.
+func NewWriter(w io.Writer) *Writer {
+	return &Writer{w: w, max: MaxSize}
+}
+
+// NewSidebandWriter returns a Writer in sideband mode. Write emits
+// [BandData] pkt-lines bounded by max total bytes (4-byte length header
+// + 1-byte band byte + payload). Use [DefaultSize] for legacy
+// side-band or [MaxSize] for sideband-64k.
+func NewSidebandWriter(w io.Writer, max int) *Writer {
+	return &Writer{w: w, sideband: true, max: max}
+}
+
+// Write implements io.Writer. In sideband mode, each pkt-line is
+// prefixed with the [BandData] byte.
+func (wr *Writer) Write(p []byte) (int, error) {
+	if wr.w == nil {
+		return 0, ErrNilWriter
+	}
+	if wr.sideband {
+		return WriteSideband(wr.w, BandData, p, wr.max)
+	}
+	return writeChunked(wr.w, p, wr.max)
+}
+
+// WriteProgress writes progress messages. In sideband mode they are
+// emitted as [BandProgress] pkt-lines; in plain mode WriteProgress is a
+// no-op (progress has no non-sideband encoding) and returns (len(p), nil).
+func (wr *Writer) WriteProgress(p []byte) (int, error) {
+	if wr.w == nil {
+		return 0, ErrNilWriter
+	}
+	if !wr.sideband {
+		return len(p), nil
+	}
+	return WriteSideband(wr.w, BandProgress, p, wr.max)
+}
+
+// Flush writes a flush-pkt (0000).
+func (wr *Writer) Flush() error {
+	return WriteFlush(wr.w)
+}
+
+// Delim writes a delim-pkt (0001).
+func (wr *Writer) Delim() error {
+	return WriteDelim(wr.w)
+}
+
+// writeChunked writes p as one or more plain pkt-lines, each bounded by
+// max total on-wire bytes (length header + payload).
+func writeChunked(w io.Writer, p []byte, max int) (int, error) {
+	if max <= LenSize {
+		return 0, errors.New("pktline: max packet size too small")
+	}
+	chunk := max - LenSize
+	if len(p) == 0 {
+		// Preserve empty-payload semantics of the top-level Write.
+		return Write(w, p)
+	}
+	written := 0
+	for len(p) > 0 {
+		n := len(p)
+		if n > chunk {
+			n = chunk
+		}
+		if _, err := Write(w, p[:n]); err != nil {
+			return written, err
+		}
+		written += n
+		p = p[n:]
+	}
+	return written, nil
+}
+
+// WriteSideband writes one or more sideband pkt-lines carrying payload
+// on the given band. Large payloads are split across multiple pkt-lines,
+// each bounded by max total on-wire bytes (4-byte length header +
+// 1-byte band byte + payload chunk). Use [DefaultSize] for legacy
+// side-band or [MaxSize] for sideband-64k.
+//
+// The returned byte count is the number of payload bytes written
+// (excluding band bytes and length headers).
+func WriteSideband(w io.Writer, band byte, payload []byte, max int) (int, error) {
+	if w == nil {
+		return 0, ErrNilWriter
+	}
+	if max <= LenSize+1 {
+		return 0, errors.New("pktline: max packet size too small for sideband")
+	}
+	chunk := max - LenSize - 1
+	if len(payload) == 0 {
+		_, err := Write(w, []byte{band})
+		return 0, err
+	}
+	buf := make([]byte, 0, max-LenSize)
+	written := 0
+	for len(payload) > 0 {
+		n := len(payload)
+		if n > chunk {
+			n = chunk
+		}
+		buf = append(buf[:0], band)
+		buf = append(buf, payload[:n]...)
+		if _, err := Write(w, buf); err != nil {
+			return written, err
+		}
+		written += n
+		payload = payload[n:]
+	}
+	return written, nil
+}

--- a/plumbing/format/pktline/writer_test.go
+++ b/plumbing/format/pktline/writer_test.go
@@ -1,0 +1,203 @@
+package pktline_test
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
+)
+
+func TestWriter_Plain_SmallPayload(t *testing.T) {
+	var buf bytes.Buffer
+	w := pktline.NewWriter(&buf)
+	n, err := w.Write([]byte("hello"))
+	if err != nil || n != 5 {
+		t.Fatalf("Write = (%d, %v)", n, err)
+	}
+	if buf.String() != "0009hello" {
+		t.Fatalf("buf = %q", buf.String())
+	}
+}
+
+func TestWriter_Plain_ChunksLargePayload(t *testing.T) {
+	// Payload larger than MaxPayloadSize must be split.
+	payload := bytes.Repeat([]byte("a"), pktline.MaxPayloadSize+10)
+	var buf bytes.Buffer
+	w := pktline.NewWriter(&buf)
+	n, err := w.Write(payload)
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if n != len(payload) {
+		t.Fatalf("n = %d, want %d", n, len(payload))
+	}
+	r := pktline.NewReader(&buf)
+	got, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("round-trip mismatch")
+	}
+}
+
+func TestWriter_Plain_EmptyPayload(t *testing.T) {
+	var buf bytes.Buffer
+	w := pktline.NewWriter(&buf)
+	if _, err := w.Write(nil); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if buf.String() != "0004" {
+		t.Fatalf("buf = %q", buf.String())
+	}
+}
+
+func TestWriter_Plain_ProgressIsNoOp(t *testing.T) {
+	var buf bytes.Buffer
+	w := pktline.NewWriter(&buf)
+	n, err := w.WriteProgress([]byte("x"))
+	if err != nil || n != 1 {
+		t.Fatalf("WriteProgress = (%d, %v)", n, err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("buf = %q", buf.String())
+	}
+}
+
+func TestWriter_Sideband_RoundTrip(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		max  int
+	}{
+		{"DefaultSize", pktline.DefaultSize},
+		{"MaxSize", pktline.MaxSize},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := bytes.Repeat([]byte("p"), tc.max*2+17)
+			var buf bytes.Buffer
+			w := pktline.NewSidebandWriter(&buf, tc.max)
+			if _, err := w.Write(payload); err != nil {
+				t.Fatalf("Write: %v", err)
+			}
+			if _, err := w.WriteProgress([]byte("counting\n")); err != nil {
+				t.Fatalf("WriteProgress: %v", err)
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("Flush: %v", err)
+			}
+
+			s := pktline.NewSidebandScanner(&buf, io.Discard, tc.max)
+			var got []byte
+			for s.Scan() {
+				if s.Len() == pktline.Flush {
+					continue
+				}
+				got = append(got, s.Bytes()...)
+			}
+			if err := s.Err(); err != nil {
+				t.Fatalf("Err: %v", err)
+			}
+			if !bytes.Equal(got, payload) {
+				t.Fatalf("round-trip mismatch (got %d bytes, want %d)", len(got), len(payload))
+			}
+		})
+	}
+}
+
+func TestWriter_Sideband_NoPktLineExceedsMax(t *testing.T) {
+	max := pktline.DefaultSize
+	payload := bytes.Repeat([]byte("x"), max*3)
+	var buf bytes.Buffer
+	w := pktline.NewSidebandWriter(&buf, max)
+	if _, err := w.Write(payload); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	s := pktline.NewScanner(&buf)
+	for s.Scan() {
+		if s.Len() > max {
+			t.Fatalf("pkt-line length %d exceeds max %d", s.Len(), max)
+		}
+	}
+	if err := s.Err(); err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+}
+
+func TestWriteSideband_BandBytePrepended(t *testing.T) {
+	var buf bytes.Buffer
+	if _, err := pktline.WriteSideband(&buf, pktline.BandError, []byte("oops"), pktline.MaxSize); err != nil {
+		t.Fatalf("WriteSideband: %v", err)
+	}
+	// 4-byte length header + 1-byte band + 4-byte payload = 9 bytes => 0009.
+	if buf.String() != "0009\x03oops" {
+		t.Fatalf("buf = %q", buf.String())
+	}
+}
+
+func TestWriteSideband_EmptyPayload(t *testing.T) {
+	var buf bytes.Buffer
+	n, err := pktline.WriteSideband(&buf, pktline.BandData, nil, pktline.MaxSize)
+	if err != nil || n != 0 {
+		t.Fatalf("WriteSideband = (%d, %v)", n, err)
+	}
+	// 4-byte length header + 1-byte band = 5 bytes => 0005.
+	if buf.String() != "0005\x01" {
+		t.Fatalf("buf = %q", buf.String())
+	}
+}
+
+func TestWriter_NilUnderlying(t *testing.T) {
+	w := pktline.NewWriter(nil)
+	if _, err := w.Write([]byte("x")); err == nil {
+		t.Fatalf("Write on nil writer succeeded")
+	}
+}
+
+func TestWriteSideband_DefaultSizeWireBound(t *testing.T) {
+	// Regression: legacy side-band pkt-lines must be strictly <= 1000
+	// bytes total. Sideband Muxer used to emit 1005-byte pkt-lines.
+	payload := bytes.Repeat([]byte("z"), 5000)
+	var buf bytes.Buffer
+	if _, err := pktline.WriteSideband(&buf, pktline.BandData, payload, pktline.DefaultSize); err != nil {
+		t.Fatal(err)
+	}
+	rest := buf.String()
+	for len(rest) >= 4 {
+		var l int
+		for i := 0; i < 4; i++ {
+			c := rest[i]
+			var v int
+			switch {
+			case c >= '0' && c <= '9':
+				v = int(c - '0')
+			case c >= 'a' && c <= 'f':
+				v = int(c-'a') + 10
+			case c >= 'A' && c <= 'F':
+				v = int(c-'A') + 10
+			default:
+				t.Fatalf("bad hex %q", rest[:4])
+			}
+			l = l*16 + v
+		}
+		if l > pktline.DefaultSize {
+			t.Fatalf("pkt-line length %d exceeds DefaultSize %d", l, pktline.DefaultSize)
+		}
+		if l < 4 || l > len(rest) {
+			t.Fatalf("bad length %d (remaining %d)", l, len(rest))
+		}
+		rest = rest[l:]
+	}
+	if rest != "" {
+		t.Fatalf("trailing bytes: %d", len(rest))
+	}
+	// Sanity: confirm the buffer parses cleanly.
+	s := pktline.NewScanner(strings.NewReader(buf.String()))
+	for s.Scan() {
+	}
+	if err := s.Err(); err != nil {
+		t.Fatalf("scan err: %v", err)
+	}
+}

--- a/plumbing/protocol/packp/sideband/demux.go
+++ b/plumbing/protocol/packp/sideband/demux.go
@@ -31,6 +31,11 @@ type Progress interface {
 // written at `Progress` (if any), if any message is retrieved from the
 // ErrorMessage channel an error is returned and we can assume that the
 // connection has been closed.
+//
+// Deprecated: use [pktline.NewSidebandReader] (for an io.Reader) or
+// [pktline.NewSidebandScanner] (for a packet-oriented scanner) instead.
+// The pktline equivalents line-buffer progress with a "remote: " prefix
+// matching git(1)'s user-facing output.
 type Demuxer struct {
 	t Type
 	r io.Reader
@@ -44,6 +49,8 @@ type Demuxer struct {
 }
 
 // NewDemuxer returns a new Demuxer for the given t and read from r
+//
+// Deprecated: use [pktline.NewSidebandReader] instead.
 func NewDemuxer(t Type, r io.Reader) *Demuxer {
 	maxSize := MaxPackedSize64k
 	if t == Sideband {

--- a/plumbing/protocol/packp/sideband/muxer.go
+++ b/plumbing/protocol/packp/sideband/muxer.go
@@ -8,6 +8,11 @@ import (
 
 // Muxer multiplex the packfile along with the progress messages and the error
 // information. The multiplex is perform using pktline format.
+//
+// Deprecated: use [pktline.NewSidebandWriter] instead. Note that the
+// pktline writer enforces the negotiated on-wire pkt-line size strictly,
+// whereas this Muxer emitted 1005-byte pkt-lines on legacy side-band
+// streams.
 type Muxer struct {
 	max int
 	w   io.Writer
@@ -20,6 +25,8 @@ const chLen = 1
 // If t is equal to `Sideband` the max pack size is set to MaxPackedSize, in any
 // other value is given, max pack is set to MaxPackedSize64k, that is the
 // maximum length of a line in pktline format.
+//
+// Deprecated: use [pktline.NewSidebandWriter] instead.
 func NewMuxer(t Type, w io.Writer) *Muxer {
 	maxSize := MaxPackedSize64k
 	if t == Sideband {

--- a/plumbing/transport/archive.go
+++ b/plumbing/transport/archive.go
@@ -89,10 +89,7 @@ func Archive(ctx context.Context, w io.WriteCloser, r io.ReadCloser, req *Archiv
 		return nil, fmt.Errorf("archive: expected flush after ACK, got data")
 	}
 
-	demuxer := sideband.NewDemuxer(sideband.Sideband64k, rd)
-	if req.Progress != nil {
-		demuxer.Progress = req.Progress
-	}
+	demuxed := pktline.NewSidebandReader(rd, req.Progress, pktline.MaxSize)
 
-	return ioutil.NewReadCloser(demuxer, r), nil
+	return ioutil.NewReadCloser(demuxed, r), nil
 }

--- a/plumbing/transport/fetch.go
+++ b/plumbing/transport/fetch.go
@@ -5,9 +5,9 @@ import (
 	"io"
 
 	"github.com/go-git/go-git/v6/plumbing/format/packfile"
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
 	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
-	"github.com/go-git/go-git/v6/plumbing/protocol/packp/sideband"
 	"github.com/go-git/go-git/v6/storage"
 	"github.com/go-git/go-git/v6/utils/ioutil"
 )
@@ -23,17 +23,18 @@ func FetchPack(
 ) error {
 	packf = ioutil.NewContextReadCloser(ctx, packf)
 
-	var demuxer *sideband.Demuxer
 	var reader io.Reader = packf
-	if caps.Supports(capability.Sideband64k) {
-		demuxer = sideband.NewDemuxer(sideband.Sideband64k, reader)
-	} else if caps.Supports(capability.Sideband) {
-		demuxer = sideband.NewDemuxer(sideband.Sideband, reader)
-	}
-
-	if demuxer != nil && req.Progress != nil {
-		demuxer.Progress = req.Progress
-		reader = demuxer
+	if req.Progress != nil {
+		max := 0
+		switch {
+		case caps.Supports(capability.Sideband64k):
+			max = pktline.MaxSize
+		case caps.Supports(capability.Sideband):
+			max = pktline.DefaultSize
+		}
+		if max > 0 {
+			reader = pktline.NewSidebandReader(reader, req.Progress, max)
+		}
 	}
 
 	if err := packfile.UpdateObjectStorage(st, reader); err != nil {

--- a/plumbing/transport/push.go
+++ b/plumbing/transport/push.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
 	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
-	"github.com/go-git/go-git/v6/plumbing/protocol/packp/sideband"
 	"github.com/go-git/go-git/v6/storage"
 	"github.com/go-git/go-git/v6/utils/ioutil"
 )
@@ -79,17 +79,19 @@ func SendPack(
 
 	var r io.Reader = reader
 	if req.Progress != nil {
-		var d *sideband.Demuxer
-		if upreq.Capabilities.Supports(capability.Sideband64k) {
-			d = sideband.NewDemuxer(sideband.Sideband64k, reader)
-		} else if upreq.Capabilities.Supports(capability.Sideband) {
-			d = sideband.NewDemuxer(sideband.Sideband, reader)
+		max := 0
+		switch {
+		case upreq.Capabilities.Supports(capability.Sideband64k):
+			max = pktline.MaxSize
+		case upreq.Capabilities.Supports(capability.Sideband):
+			max = pktline.DefaultSize
 		}
-		if d != nil {
-			if !upreq.Capabilities.Supports(capability.Quiet) {
-				d.Progress = req.Progress
+		if max > 0 {
+			progress := req.Progress
+			if upreq.Capabilities.Supports(capability.Quiet) {
+				progress = nil
 			}
-			r = d
+			r = pktline.NewSidebandReader(reader, progress, max)
 		}
 	}
 

--- a/plumbing/transport/receive_pack.go
+++ b/plumbing/transport/receive_pack.go
@@ -12,7 +12,6 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/protocol"
 	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
-	"github.com/go-git/go-git/v6/plumbing/protocol/packp/sideband"
 	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/storage"
 	"github.com/go-git/go-git/v6/utils/ioutil"
@@ -133,10 +132,10 @@ func ReceivePack(
 	)
 	if !caps.Supports(capability.NoProgress) {
 		if caps.Supports(capability.Sideband64k) {
-			writer = sideband.NewMuxer(sideband.Sideband64k, w)
+			writer = pktline.NewSidebandWriter(w, pktline.MaxSize)
 			useSideband = true
 		} else if caps.Supports(capability.Sideband) {
-			writer = sideband.NewMuxer(sideband.Sideband, w)
+			writer = pktline.NewSidebandWriter(w, pktline.DefaultSize)
 			useSideband = true
 		}
 	}

--- a/plumbing/transport/upload_archive.go
+++ b/plumbing/transport/upload_archive.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/go-git/go-git/v6/internal/archive"
 	"github.com/go-git/go-git/v6/plumbing/format/pktline"
-	"github.com/go-git/go-git/v6/plumbing/protocol/packp/sideband"
 	"github.com/go-git/go-git/v6/storage"
 	"github.com/go-git/go-git/v6/utils/ioutil"
 )
@@ -55,7 +54,7 @@ func UploadArchive(
 		return fmt.Errorf("upload-archive: writing flush: %w", err)
 	}
 
-	mux := sideband.NewMuxer(sideband.Sideband64k, w)
+	mux := pktline.NewSidebandWriter(w, pktline.MaxSize)
 
 	format := "tar"
 	prefix := ""
@@ -184,10 +183,10 @@ func writeNACK(w io.Writer, reason string) {
 
 // muxError writes an error to the sideband error channel and flushes.
 // Returns the original error for convenience.
-func muxError(mux *sideband.Muxer, w io.Writer, err error) error {
+func muxError(mux *pktline.Writer, w io.Writer, err error) error {
 	errMsg := fmt.Sprintf("upload-archive: %s", err.Error())
-	_, _ = mux.WriteChannel(sideband.ErrorMessage, []byte(errMsg))
-	_ = pktline.WriteFlush(w)
+	_, _ = pktline.WriteSideband(w, pktline.BandError, []byte(errMsg), pktline.MaxSize)
+	_ = mux.Flush()
 	return err
 }
 

--- a/plumbing/transport/upload_pack.go
+++ b/plumbing/transport/upload_pack.go
@@ -15,7 +15,6 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/protocol"
 	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
-	"github.com/go-git/go-git/v6/plumbing/protocol/packp/sideband"
 	"github.com/go-git/go-git/v6/plumbing/revlist"
 	"github.com/go-git/go-git/v6/storage"
 	"github.com/go-git/go-git/v6/utils/ioutil"
@@ -265,10 +264,10 @@ func UploadPack(
 		writer      io.Writer = w
 	)
 	if caps.Supports(capability.Sideband64k) {
-		writer = sideband.NewMuxer(sideband.Sideband64k, w)
+		writer = pktline.NewSidebandWriter(w, pktline.MaxSize)
 		useSideband = true
 	} else if caps.Supports(capability.Sideband) {
-		writer = sideband.NewMuxer(sideband.Sideband, w)
+		writer = pktline.NewSidebandWriter(w, pktline.DefaultSize)
 		useSideband = true
 	}
 


### PR DESCRIPTION
## What

Collapses sideband demux/mux into the `pktline` package, mirroring upstream Git's `packet_reader` / `packet_writer` shape. Adds a sideband-aware `Scanner` mode, `Reader` and `Writer` adapters, and a low-level `WriteSideband` helper. Migrates all in-tree consumers and deprecates `sideband.Demuxer` / `sideband.Muxer`.

## Why

`sideband.Demuxer` and `sideband.Muxer` predate the `pktline.Scanner` redesign and duplicate framing logic that already lives in `pktline`. Routing band selection through `pktline` removes the duplication, lets every consumer share one buffered packet reader, and brings progress output in line with canonical Git (`"remote: "` prefix, line-buffered to avoid garbled terminal output).

The work also fixes a wire-format bug along the way: `sideband.Muxer` emitted **1005-byte pkt-lines** on legacy side-band streams that negotiate a 1000-byte cap. The new `Writer` enforces the bound strictly.

See [RFC 0007](rfcs/0007-unified-pktline-scanner-sideband.md) for the full design.

## Commits

| Commit | Subject |
|---|---|
| C1 | `plumbing: format/pktline, add sideband Scanner mode` |
| C2 | `plumbing: format/pktline, add Reader` |
| C3 | `plumbing: format/pktline, add Writer and WriteSideband` |
| C4 | `plumbing: transport, migrate sideband demuxer consumers` |
| C5 | `plumbing: transport, migrate sideband muxer consumers` |
| C6 | `plumbing: protocol/packp/sideband, deprecate Demuxer and Muxer` |

Each commit leaves the tree green (build + tests).

## Notable behavior changes

- Progress (band-2) is now line-buffered and prefixed with `"remote: "` before reaching the caller's progress writer. Callers that asserted exact bytes on `Progress` will see prefixed lines instead of raw payloads.
- Legacy side-band pkt-lines are now strictly ≤ 1000 bytes on the wire (was 1005).
- Sideband zero-length data packets surface as a protocol error, matching upstream Git's `demultiplex_sideband`.

## Tests

- Table-driven tests for `Scanner` sideband mode, `Reader`, and `Writer`.
- Three new fuzz targets: `FuzzSidebandScanner`, `FuzzSidebandReader`, `FuzzSidebandRoundTrip` (each runs cleanly for 5 s during local validation).
- `./plumbing/...` is green. The two failures on the parent `pktline-scanner` branch (`TestSubmoduleUpdateWithInitAndUpdate`, `TestWorktreeSuite/TestCommitTreeSort`) reproduce without this PR and are unrelated.

## Follow-ups (not in this PR)

Since v6 is not yet fully released, the following can land as breaking changes ahead of the v6 release rather than waiting for v7:

- Drop `sideband.Progress` as a field type from the public option structs (`CloneOptions`, `PullOptions`, `FetchOptions`, `PushOptions`, `FetchRequest`, `PushRequest`, `ArchiveRequest`) in favour of `io.Writer`.
- Migrate the remaining `sideband.NewDemuxer` usage in `plumbing/transport/upload_pack_test.go` and tidy up the lingering doc references to `sideband.PackData` / `sideband.Demuxer`.
- Once the public API no longer references the deprecated types, remove `sideband.{Demuxer, Muxer}` outright.

## AI assistance

This PR was prepared with AI assistance (Copilot) per `AI_POLICY.md`. Each commit carries an `Assisted-by:` trailer.
